### PR TITLE
feat: Remove Goreleaser and build manually on all platforms

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 on:
-  push: {}
+  push:
+    branches-ignore:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,15 @@ env:
 permissions:
   contents: write
 
-name: Release
+name: Build & Release
 jobs:
-  release:
+  build:
     if: startsWith(github.ref, 'refs/tags/v')
-    name: Release
-    runs-on: ubuntu-latest
+    name: Build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     #needs: [ test ]
     steps:
     - name: Checkout
@@ -42,15 +45,53 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
       shell: /bin/bash -e {0}
 
-    - name: Print build tag
-      run: echo "${VERSION}"
+    - name: Build artefacts
+      run: |
+        echo "${VERSION} on ${{ matrix.os }}"
+        make ${{ matrix.os }}
 
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
       with:
-        version: '~> v2' # latest
-        args: release --clean
-        workdir: .
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: ${{ env.VERSION }}
+        name: aws-vault-${{ matrix.os }}
+        retention-days: 7
+        path: ./aws-vault-*
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        run: |
+          cp dist/*aws-vault-* .
+          make aws-vault_sha256_checksums.txt
+          cp aws-vault_sha256_checksums.txt dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/**
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          body: "Changelog of release ${{ github.ref_name }}."
+          append_body: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    #- name: Run GoReleaser
+    #  uses: goreleaser/goreleaser-action@v6
+    #  with:
+    #    version: '~> v2' # latest
+    #    args: release --clean
+    #    workdir: .
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #    VERSION: ${{ env.VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint:
 vet:
 	go vet -all ./...
 
-release: binaries dmgs SHA256SUMS
+release: binaries SHA256SUMS
 
 	@echo "\nTo create a new release run:\n\n    gh release create --title $(VERSION) $(VERSION) \
 	aws-vault-darwin-amd64.dmg \
@@ -58,6 +58,10 @@ release: binaries dmgs SHA256SUMS
 	SHA256SUMS\n"
 
 	@echo "\nTo update homebrew-cask run:\n\n    brew bump-cask-pr --version $(shell echo $(VERSION) | sed 's/v\(.*\)/\1/') aws-vault\n"
+
+ubuntu-latest: aws-vault-linux-amd64 aws-vault-linux-arm64 #aws-vault-linux-ppc64le aws-vault-linux-arm7 aws-vault-windows-386.exe aws-vault-windows-arm64.exe
+
+macos-latest: aws-vault-darwin-amd64 aws-vault-darwin-arm64
 
 aws-vault-darwin-amd64: $(SRC)
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path) go build $(BUILD_FLAGS) -o $@ .
@@ -91,6 +95,11 @@ aws-vault-darwin-amd64.dmg: aws-vault-darwin-amd64
 
 aws-vault-darwin-arm64.dmg: aws-vault-darwin-arm64
 	./bin/create-dmg aws-vault-darwin-arm64 $@
+
+aws-vault_sha256_checksums.txt:
+	sha256sum \
+	  aws-vault-* \
+	    > $@
 
 SHA256SUMS: binaries dmgs
 	shasum -a 256 \


### PR DESCRIPTION
Necessary for CGO linking. Also Generate checksums for the releases.