### PR TITLE
chore: Vendor dependencies and bump versions

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/prompt"

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
 )

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/iso8601"

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/alecthomas/kingpin/v2"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 )
 
 func ExampleExecCommand() {

--- a/cli/export.go
+++ b/cli/export.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/iso8601"

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/alecthomas/kingpin/v2"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 )
 
 func ExampleExportCommand() {

--- a/cli/global.go
+++ b/cli/global.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/prompt"
 	"github.com/byteness/aws-vault/v7/vault"

--- a/cli/list.go
+++ b/cli/list.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
 )

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/alecthomas/kingpin/v2"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 )
 
 func ExampleListCommand() {

--- a/cli/login.go
+++ b/cli/login.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/prompt"
 	"github.com/byteness/aws-vault/v7/vault"

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/byteness/aws-vault/v7
 go 1.24
 
 require (
-	github.com/99designs/keyring v1.2.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/aws/aws-sdk-go-v2 v1.36.4
 	github.com/aws/aws-sdk-go-v2/config v1.29.16
@@ -12,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.4
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.21
+	github.com/byteness/keyring v1.2.3
 	github.com/google/go-cmp v0.7.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-tty v0.0.7
@@ -21,7 +21,6 @@ require (
 )
 
 require (
-	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.31 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.35 // indirect
@@ -30,11 +29,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.16 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/byteness/percent v0.2.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
-	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
-github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
-github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
@@ -34,6 +30,12 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.21 h1:nyLjs8sYJShFYj6aiyjCBI3EcLn
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.21/go.mod h1:EhdxtZ+g84MSGrSrHzZiUm9PYiZkrADNja15wtRJSJo=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK19hYuXB8OQ0rTO9WOCgZY9JUy964zaYawY=
+github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
+github.com/byteness/keyring v1.2.3 h1:WsC4rYrwnAJRDuq8WhsbWcO1fs7OvahzRTxvJDoYVFs=
+github.com/byteness/keyring v1.2.3/go.mod h1:ACTZ0DgnDS162t65tDhBWczY79A4fZz2AjvYtpfh0MQ=
+github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=
+github.com/byteness/percent v0.2.2/go.mod h1:nwavge92FhIyfnldz4YWZD8uxPVvdh8NlzLRd1VYRDs=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,8 +56,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
-github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
-github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/vault/credentialkeyring.go
+++ b/vault/credentialkeyring.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 

--- a/vault/oidctokenkeyring.go
+++ b/vault/oidctokenkeyring.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 )
 

--- a/vault/sessionkeyring.go
+++ b/vault/sessionkeyring.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 

--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/sso"

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/99designs/keyring"
+	"github.com/byteness/keyring"
 	"github.com/byteness/aws-vault/v7/vault"
 )
 


### PR DESCRIPTION
Pull keyring dependencies into this org and ensure availability/longevity for future builds.