### PR TITLE
feat: Add ENV variable for auto-logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Here's what you can expect from aws-vault
 | `aws-vault exec bar-role2`               | session-token + role + role | session-token | Yes |
 | `aws-vault exec bar-role2 --no-session`  | role + role                 | role          | Yes |
 
+## Auto-logout
+
+Since v7.3+ `aws-vault` will automatically try to do a logout first before login when executing `aws-vault login <profile>`.
+
+This behavour can be disabled using `--no-autologout` or `-a` flags! Read more in [USAGE.md](./USAGE.md) file.
+
 ## Development
 
 The [macOS release builds](https://github.com/byteness/aws-vault/releases) are code-signed to avoid extra prompts in Keychain. You can verify this with:

--- a/USAGE.md
+++ b/USAGE.md
@@ -272,6 +272,7 @@ WARNING: Use of this option runs against security best practices. It is recommen
 To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_BACKEND`: Secret backend to use (see the flag `--backend`)
 * `AWS_VAULT_KEYCHAIN_NAME`: Name of macOS keychain to use (see the flag `--keychain`)
+* `AWS_VAULT_NO_AUTOLOGOUT`: Disable autologout when doing `login` (see the flag `--no-autologout`)
 * `AWS_VAULT_PROMPT`: Prompt driver to use (see the flag `--prompt`)
 * `AWS_VAULT_PASS_PASSWORD_STORE_DIR`: Pass password store directory (see the flag `--pass-dir`)
 * `AWS_VAULT_PASS_CMD`: Name of the pass executable (see the flag `--pass-cmd`)
@@ -437,6 +438,10 @@ You can use the `aws-vault login` command to open a browser window and login to 
 ```shell
 $ aws-vault login work
 ```
+
+> [!NOTE]
+> When using multi-session support in AWS Management console you might need to disable auto-logout using `--no-autologout` or `-a`.
+> Otherwise URL redirect won't work and you'll end up with HTTP/400 response.
 
 If you have credentials already available in your environment, aws-vault will use these credentials to sign you in to the AWS console.
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 	"github.com/skratchdot/open-golang/open"
 )
 
@@ -46,6 +46,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 
 	cmd.Flag("no-autologout", "Don't auto logout when starting a new login").
 		Short('a').
+		Envar("AWS_VAULT_NO_AUTOLOGOUT").
 		BoolVar(&input.NoAutoLogout)
 
 	cmd.Flag("mfa-token", "The MFA token to use").


### PR DESCRIPTION
Fixes #23 

* Adds an ENV variable to disable auto-logout. It's required when using multi-session in AWS Console