### PR TITLE
feat: Add rotate profile selection

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -417,6 +417,8 @@ The minimal IAM policy required to rotate your own credentials is:
 }
 ```
 
+> [!TIP]
+> If you omit AWS profile name `aws-vault` will ask you to select from the list of configured profiles in AWS config - similar to when logging into AWS Console.
 
 ## Managing Sessions
 

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 type RotateCommandInput struct {
@@ -29,19 +29,31 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 		BoolVar(&input.NoSession)
 
 	cmd.Arg("profile", "Name of the profile").
-		Required().
+		//Required().
 		HintAction(a.MustGetProfileNames).
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
 		input.Config.MfaPromptMethod = a.PromptDriver(false)
+
+		f, err := a.AwsConfigFile()
+		if err != nil {
+			return err
+		}
 		keyring, err := a.Keyring()
 		if err != nil {
 			return err
 		}
-		f, err := a.AwsConfigFile()
-		if err != nil {
-			return err
+
+		if input.ProfileName == "" {
+			// If no profile provided select from configured AWS profiles
+			ProfileName, err := pickAwsProfile(f.ProfileNames())
+
+			if err != nil {
+				return fmt.Errorf("unable to select a 'profile'. Try --help: %w", err)
+			}
+
+			input.ProfileName = ProfileName
 		}
 
 		err = RotateCommand(input, f, keyring)


### PR DESCRIPTION
Fixes: #36 

Implements a fallback to select a profile when running `rotate` and not providing a name.