### PR TITLE
chore: Detect prerelease version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches-ignore:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '.gitgnore'
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Identify if this is a pre release by checking if the tag name contains -rc, -b, -a
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-b') || contains(github.ref, '-a') }}
           files: |
             dist/**
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Automatically mark release as `prerelease` when using `-rc`, `-a` or `-b` tag suffixes.