### PR TITLE
fix: Broken MFA process on Windows

### DIFF
--- a/vault/mfa.go
+++ b/vault/mfa.go
@@ -2,11 +2,7 @@ package vault
 
 import (
 	"errors"
-	"fmt"
 	"log"
-	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/prompt"
@@ -47,13 +43,5 @@ func NewMfa(config *ProfileConfig) Mfa {
 }
 
 func ProcessMfaProvider(processCmd string) (string, error) {
-	cmd := exec.Command("/bin/sh", "-c", processCmd)
-	cmd.Stderr = os.Stderr
-
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("process provider: %w", err)
-	}
-
-	return strings.TrimSpace(string(out)), nil
+	return executeMFACommand(processCmd)
 }

--- a/vault/mfa_unix.go
+++ b/vault/mfa_unix.go
@@ -1,0 +1,23 @@
+//go:build linux || darwin || freebsd || openbsd
+// +build linux darwin freebsd openbsd
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func executeMFACommand(processCmd string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", processCmd)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("process provider: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}

--- a/vault/mfa_windows.go
+++ b/vault/mfa_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+// +build windows
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func executeMFACommand(processCmd string) (string, error) {
+	// On windows, its quite involved to launch a process if the binary involved is in a path with spaces
+	// See https://github.com/golang/go/issues/17149 for details and workaround proposals
+	shell := os.Getenv("SystemRoot") + "\\System32\\cmd.exe"
+	cmd := exec.Command(shell)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "/C \"" + processCmd + "\""}
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("process provider: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
Fixes: https://github.com/99designs/aws-vault/issues/1241 https://github.com/99designs/aws-vault/pull/1255

Properly handle MFA process on Windows, where shell is invoked using `cmd.exe` not `sh`