### PR TITLE
chore: Bump Keyring to 1.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
-	github.com/byteness/keyring v1.3.1
+	github.com/byteness/keyring v1.3.2
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK1
 github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
 github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c h1:acX3x2Ka/6jQt3inHLNUuL1IKxb/j4dNMbuL6B/N324=
 github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c/go.mod h1:eVg/Qgq8PRiBljsgvBLlVpMSrLecEY8pINiVRKQYYdc=
-github.com/byteness/keyring v1.3.1 h1:TcLJFyasrVr3jFS27RAM7mmnQbR6iNr+rqU+EEIoyJk=
-github.com/byteness/keyring v1.3.1/go.mod h1:q9VT1fwDemDLTXziMqX3OaWivdFq8kF7NhknCtm+RfY=
+github.com/byteness/keyring v1.3.2 h1:LyQL/Vk+ZR/+nZN9JDA9WgEVAql47EkuzDncfzUzM8s=
+github.com/byteness/keyring v1.3.2/go.mod h1:sx/TmXlWjUg9nKIjdyPL7tt8BxL5S9V4J3xRD+DNsnY=
 github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=
 github.com/byteness/percent v0.2.2/go.mod h1:nwavge92FhIyfnldz4YWZD8uxPVvdh8NlzLRd1VYRDs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=


### PR DESCRIPTION
Update Golang deps