### PR TITLE
fix: Ordering or GHA release steps

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read  # This is required for the label PR action
+  pull-requests: write # This is required for the label PR action
+
 jobs:
   validate-pr-title:
     name: Validate PR
     runs-on: ubuntu-latest
-    permissions:
-      contents: read  # This is required for the label PR action
-      pull-requests: write # This is required for the label PR action
     steps:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.1
@@ -22,10 +23,9 @@ jobs:
   labeler:
     name: Label PRs
     runs-on: ubuntu-latest
-    permissions:
-      contents: read  # This is required for the label PR action
-      pull-requests: write # This is required for the label PR action
     steps:
       - name: Label PRs
         id: label-prs
         uses: actions/labeler@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,15 +74,15 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Compress binaries with upx
+        run: upx dist/aws-vault-{linux,windows-amd64}*
+
       - name: Generate SHA256 checksums
         run: |
           cp dist/aws-vault-* .
           chmod +x dist/* aws-vault-*
           make aws-vault_sha256_checksums.txt
           cp aws-vault_sha256_checksums.txt dist/
-
-      - name: Compress binaries with upx
-        run: upx dist/aws-vault-{linux,windows-amd64}*
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install upx
+      - name: Install UPX
         run: sudo apt-get update && sudo apt-get install -y upx
 
       - name: Download Artifacts
@@ -74,7 +74,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Compress binaries with upx
+      - name: Compress binaries with UPX
         run: upx dist/aws-vault-{linux,windows-amd64}*
 
       - name: Generate SHA256 checksums


### PR DESCRIPTION
Related: #60 

Compress binaries before calculating checksums and avoid inconsistentices.