### PR TITLE
chore: Disable UPX for Windows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,8 +65,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install UPX
-        run: sudo apt-get update && sudo apt-get install -y upx
+      #- name: Install UPX
+      #  run: sudo apt-get update && sudo apt-get install -y upx
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -74,8 +74,9 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Compress binaries with UPX
-        run: upx dist/aws-vault-{linux,windows-amd64}*
+      # NOTE: Disabled due Chocolately AV false positives
+      #- name: Compress binaries with UPX
+      #  run: upx dist/aws-vault-{linux,windows-amd64}*
 
       - name: Generate SHA256 checksums
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,8 +65,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      #- name: Install UPX
-      #  run: sudo apt-get update && sudo apt-get install -y upx
+      - name: Install UPX
+        run: sudo apt-get update && sudo apt-get install -y upx
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -74,9 +74,9 @@ jobs:
           path: dist
           merge-multiple: true
 
-      # NOTE: Disabled due Chocolately AV false positives
-      #- name: Compress binaries with UPX
-      #  run: upx dist/aws-vault-{linux,windows-amd64}*
+      # NOTE: Disabled for windows-amd64 due Chocolately AV false positives
+      - name: Compress binaries with UPX
+        run: upx dist/aws-vault-{linux,freebsd}*
 
       - name: Generate SHA256 checksums
         run: |

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ release: binaries SHA256SUMS
 
 	@echo "\nTo update homebrew-cask run:\n\n    brew bump-cask-pr --version $(shell echo $(VERSION) | sed 's/v\(.*\)/\1/') aws-vault\n"
 
-ubuntu-latest: aws-vault-linux-amd64 aws-vault-linux-arm64 aws-vault-windows-amd64.exe aws-vault-windows-arm64.exe
+ubuntu-latest: aws-vault-linux-amd64 aws-vault-linux-arm64 aws-vault-windows-amd64.exe aws-vault-windows-arm64.exe aws-vault-freebsd-amd64
 
 macos-latest: aws-vault-darwin-amd64 aws-vault-darwin-arm64
 


### PR DESCRIPTION
Related: #60 

* There are AV false positives on Chocolately, let's disable it for Windows.
* Also enable FreeBSD builds
