### PR TITLE
Fix credential method selection for chained vs non-chained MFA

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -267,12 +267,13 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 
 	if isMasterCredentialsProvider(sourcecredsProvider) || isChainedCredentialSource {
 		canUseGetSessionToken, reason := t.canUseGetSessionToken(config)
-		if canUseGetSessionToken {
-			t.chainedMfa = config.MfaSerial
-			log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
-			return NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
+		if !canUseGetSessionToken {
+			log.Printf("profile %s: skipping GetSessionToken because %s", config.ProfileName, reason)
+			return sourcecredsProvider, nil
 		}
-		log.Printf("profile %s: skipping GetSessionToken because %s", config.ProfileName, reason)
+		t.chainedMfa = config.MfaSerial
+		log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
+		return NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
 	}
 
 	return sourcecredsProvider, nil

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -257,7 +257,7 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 	isChainedCredentialSource := config.ChainedFromProfile != nil
 
 	if config.HasRole() && !isChainedCredentialSource {
-		isMfaChained := config.SourceProfile != nil && config.MfaSerial == config.SourceProfile.MfaSerial
+		isMfaChained := config.MfaSerial != "" && config.MfaSerial == t.chainedMfa
 		if isMfaChained {
 			config.MfaSerial = ""
 		}


### PR DESCRIPTION
## Introduction

After my changes, I notice that I broke some features when I was trying to pass the session duration to my `PROFILENAME`.

```
$ avault76 login PROFILENAME -d 8h --debug                    
2025/08/16 16:37:20 aws-vault v7.6.0-rc1
2025/08/16 16:37:20 Using prompt driver: terminal
2025/08/16 16:37:20 [keyring] Considering backends: [secret-service]
2025/08/16 16:37:20 Loading config file /home/***/.aws/config
2025/08/16 16:37:20 Parsing config file /home/***/.aws/config
2025/08/16 16:37:20 profile PROFILENAME: using stored credentials
2025/08/16 16:37:20 profile PROFILENAME: skipping GetSessionToken because sessions are disabled for this profile
2025/08/16 16:37:20 profile PROFILENAME: using GetSessionToken (with MFA)
2025/08/16 16:37:20 profile PROFILENAME: using AssumeRole (chained MFA)
2025/08/16 16:37:20 Re-using cached credentials ****************ICW7 from sts.GetSessionToken, expires in 7h12m54.65693466s
aws-vault: error: login: operation error STS: AssumeRole, https response error StatusCode: 400, RequestID: 2d939bc8-4d67-4019-a676-2b87ed6e3bf8, api error ValidationError: The requested DurationSeconds exceeds the 1 hour session limit for roles assumed by role chaining.
```
In this example, you can notice that we are dealing it as a `(chained MFA)`, that is not the truth.

## Fixed
This problem occurs because the: https://github.com/ByteNess/aws-vault/blob/7500108301cf80f75e008d809eb9e9654e18d40e/vault/vault.go#L344-L346

Notice that previously I was handling both methods as **chained credentials**, so to use this feature `--duration`, we must use the right method at the right time

I could get it working in both cases by using `NewSessionTokenProvider` in the **SOURCE** profile when we have `config.ChainedFromProfile != nil`

## Cached Credentials

https://github.com/ByteNess/aws-vault/blob/7500108301cf80f75e008d809eb9e9654e18d40e/vault/sessionkeyring.go#L103-L114

After debugging, I found it:
```
 key github.com/99designs/aws-vault/v7/vault.SessionMetadata = vault.SessionMetadata {Type: "sts.GetSessionToken", ProfileName: "PROFILENAME", MfaSerial: "arn:aws:iam::***:mfa/***", Expiration: time.Time(0001-01-01T00:00:00Z){wall: 0, ext: 0, loc: *time.Location nil}}
   Type string = "sts.GetSessionToken"
   ProfileName string = "PROFILENAME"
   MfaSerial string = "arn:aws:iam::***:mfa/***"
  Expiration time.Time = time.Time(0001-01-01T00:00:00Z){wall: 0, ext: 0, loc: *time.Location nil}
    wall uint64 = 0 = 0x0
    ext int64 = 0
    loc *time.Location = *time.Location nil
```

```
strings.HasPrefix
  keyName:                 sts.AssumeRole,YWNr,YXJuOmF3czppYW06OjM4MDg2NTgzMDYxNTptZmEZQ,1755390794
  key.StringForMatching(): sts.GetSessionToken,YWNr,YXJuOmF3czppYW06OjM4MDg2NTgzMDYxNTptZmEZQ,
```

Notice that we only reuse if we use the same sts get credential method,
I tried to bypass it but got a **403 Forbidden**. So I'll leave it unchanged, because i cannot find a way to do it better


## Conclusion

aws-vault after a login without role chaining

```
Enter MFA code for arn:aws:iam::***:mfa/***: 
$ aws-vault list

Profile                          Credentials                      Sessions                                        
=======                          ===========                      ========                                        
PROFILENAME                      PROFILENAME                      sts.GetSessionToken:7h59m59s
```

aws-vault after a login with role chaining

```
$ aws-vault list

Profile                          Credentials                      Sessions                                        
=======                          ===========                      ========                                        
PROFILENAME                      PROFILENAME                      sts.AssumeRole:59m59s
```

aws-vault after both
```
$ aws-vault list

Profile                          Credentials                      Sessions                                        
=======                          ===========                      ========                                        
PROFILENAME                      PROFILENAME                      sts.GetSessionToken:7h59m18s, sts.AssumeRole:59m52s
```

So, we must provide `Enter MFA code for arn:aws:iam::***:mfa/***:` for each method.