### PR TITLE
chore: Introduce AWS_VAULT_STDOUT as env var to configure the --stdout flag

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -289,6 +289,7 @@ To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_OP_CONNECT_TOKEN`: 1Password Connect server access token
 * `AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN`: 1Password service account token
 * `AWS_CONFIG_FILE`: The location of the AWS config file
+* `AWS_VAULT_STDOUT`: Print login URL to stdout instead of opening in default browser (see the flag `--stdout`)
 
 To override the AWS config file (used in the `exec`, `login` and `rotate` subcommands):
 * `AWS_REGION`: The AWS region

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -105,6 +105,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 		BoolVar(&input.Lazy)
 
 	cmd.Flag("stdout", "Print the SSO link to the terminal without automatically opening the browser").
+		OverrideDefaultFromEnvar("AWS_VAULT_STDOUT").
 		BoolVar(&input.UseStdout)
 
 	cmd.Arg("profile", "Name of the profile").

--- a/cli/export.go
+++ b/cli/export.go
@@ -57,6 +57,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 		EnumVar(&input.Format, FormatTypeEnv, FormatTypeExportEnv, FormatTypeExportJSON, FormatTypeExportINI)
 
 	cmd.Flag("stdout", "Print the SSO link to the terminal without automatically opening the browser").
+		OverrideDefaultFromEnvar("AWS_VAULT_STDOUT").
 		BoolVar(&input.UseStdout)
 
 	cmd.Arg("profile", "Name of the profile").

--- a/cli/login.go
+++ b/cli/login.go
@@ -61,6 +61,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.Config.Region)
 
 	cmd.Flag("stdout", "Print login URL to stdout instead of opening in default browser").
+		OverrideDefaultFromEnvar("AWS_VAULT_STDOUT").
 		Short('s').
 		BoolVar(&input.UseStdout)
 


### PR DESCRIPTION
Sometimes it's tedious to add `--stdout` on all invocations of `aws-vault`, this allows it to be configured as an evironment variable for all times.

Especially useful when your main browser is not the one that's logged in to AWS (I'm shuffling dozens of aws accounts AND browsers at the same time).