### PR TITLE
feat: Adding support for custom endpoint URL

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -295,6 +295,7 @@ To override the AWS config file (used in the `exec`, `login` and `rotate` subcom
 * `AWS_REGION`: The AWS region
 * `AWS_DEFAULT_REGION`: The AWS region, applied only if `AWS_REGION` isn't set
 * `AWS_STS_REGIONAL_ENDPOINTS`: STS endpoint resolution logic, must be "regional" or "legacy"
+* `AWS_ENDPOINT_URL`: The AWS endpoint URL to use
 * `AWS_MFA_SERIAL`: The identification number of the MFA device to use
 * `AWS_ROLE_ARN`: Specifies the ARN of an IAM role in the active profile
 * `AWS_ROLE_SESSION_NAME`: Specifies the name to attach to the role session in the active profile

--- a/cli/login.go
+++ b/cli/login.go
@@ -251,7 +251,7 @@ func generateLoginURL(region string, path string) (string, string) {
 }
 
 func isCallerIdentityAssumedRole(ctx context.Context, credsProvider aws.CredentialsProvider, config *vault.ProfileConfig) (bool, error) {
-	cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints)
+	cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints, config.EndpointURL)
 	client := sts.NewFromConfig(cfg)
 	id, err := client.GetCallerIdentity(ctx, nil)
 	if err != nil {

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -103,7 +103,7 @@ func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyrin
 		}
 	}
 
-	cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints)
+	cfg := vault.NewAwsConfigWithCredsProvider(credsProvider, config.Region, config.STSRegionalEndpoints, config.EndpointURL)
 
 	// A username is needed for some IAM calls if the credentials have assumed a role
 	iamUserName, err := getUsernameIfAssumingRole(context.TODO(), cfg, config)

--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -125,7 +125,7 @@ func (e *EcsServer) getRoleProvider(roleArn string) aws.CredentialsProvider {
 	if ok {
 		roleProviderCache = v.(*aws.CredentialsCache)
 	} else {
-		cfg := vault.NewAwsConfigWithCredsProvider(e.baseCredsProvider, e.config.Region, e.config.STSRegionalEndpoints)
+		cfg := vault.NewAwsConfigWithCredsProvider(e.baseCredsProvider, e.config.Region, e.config.STSRegionalEndpoints, e.config.EndpointURL)
 		roleProvider := &vault.AssumeRoleProvider{
 			StsClient: sts.NewFromConfig(cfg),
 			RoleARN:   roleArn,

--- a/vault/config.go
+++ b/vault/config.go
@@ -141,6 +141,7 @@ type ProfileSection struct {
 	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
 	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
 	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
+	EndpointURL             string `ini:"endpoint_url,omitempty"`
 	SessionTags             string `ini:"session_tags,omitempty"`
 	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
 	SourceIdentity          string `ini:"source_identity,omitempty"`
@@ -381,6 +382,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *ProfileConfig, profileNam
 	if config.STSRegionalEndpoints == "" {
 		config.STSRegionalEndpoints = psection.STSRegionalEndpoints
 	}
+	if config.EndpointURL == "" {
+		config.EndpointURL = psection.EndpointURL
+	}
 	if config.SourceIdentity == "" {
 		config.SourceIdentity = psection.SourceIdentity
 	}
@@ -434,6 +438,11 @@ func (cl *ConfigLoader) populateFromEnv(profile *ProfileConfig) {
 	if stsRegionalEndpoints := os.Getenv("AWS_STS_REGIONAL_ENDPOINTS"); stsRegionalEndpoints != "" && profile.STSRegionalEndpoints == "" {
 		log.Printf("Using %q from AWS_STS_REGIONAL_ENDPOINTS", stsRegionalEndpoints)
 		profile.STSRegionalEndpoints = stsRegionalEndpoints
+	}
+
+	if endpointURL := os.Getenv("AWS_ENDPOINT_URL"); endpointURL != "" && profile.EndpointURL == "" {
+		log.Printf("Using %q from AWS_ENDPOINT_URL", endpointURL)
+		profile.EndpointURL = endpointURL
 	}
 
 	if mfaSerial := os.Getenv("AWS_MFA_SERIAL"); mfaSerial != "" && profile.MfaSerial == "" {
@@ -555,6 +564,9 @@ type ProfileConfig struct {
 
 	// STSRegionalEndpoints sets STS endpoint resolution logic, must be "regional" or "legacy"
 	STSRegionalEndpoints string
+
+	// EndpointURL specifies custom endpoint URL
+	EndpointURL string
 
 	// Mfa config
 	MfaSerial       string

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -33,6 +33,10 @@ Region=us-east-1
 duration_seconds=1200
 sts_regional_endpoints=legacy
 
+[profile withendpointurl]
+region=us-east-1
+endpoint_url=https://localhost:1234
+
 [profile testincludeprofile1]
 region=us-east-1
 
@@ -114,6 +118,7 @@ func TestConfigParsingProfiles(t *testing.T) {
 		{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
 		{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
 		{vault.ProfileSection{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"}, true},
+		{vault.ProfileSection{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"}, true},
 		{vault.ProfileSection{Name: "nopenotthere"}, false},
 	}
 
@@ -168,6 +173,7 @@ func TestProfilesFromConfig(t *testing.T) {
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
 		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
+		{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
 		{Name: "testincludeprofile1", Region: "us-east-1"},
 		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 		{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},
@@ -203,6 +209,7 @@ func TestAddProfileToExistingConfig(t *testing.T) {
 		{Name: "user2", Region: "us-east-1"},
 		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
 		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
+		{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
 		{Name: "testincludeprofile1", Region: "us-east-1"},
 		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
 		{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},

--- a/vault/stsendpointresolver.go
+++ b/vault/stsendpointresolver.go
@@ -9,8 +9,17 @@ import (
 
 // getEndpointResolver resolves endpoints in accordance with
 // https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-sts_regional_endpoints.html
-func getSTSEndpointResolver(stsRegionalEndpoints string) aws.EndpointResolverWithOptionsFunc {
+func getSTSEndpointResolver(stsRegionalEndpoints, endpointURL string) aws.EndpointResolverWithOptionsFunc {
 	return func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		if endpointURL != "" {
+			log.Println("Using custom STS endpoint " + endpointURL)
+
+			return aws.Endpoint{
+				URL:           endpointURL,
+				SigningRegion: region,
+			}, nil
+		}
+
 		if stsRegionalEndpoints == "legacy" && service == sts.ServiceID {
 			if region == "ap-northeast-1" ||
 				region == "ap-south-1" ||


### PR DESCRIPTION
Adding support for custom endpoint URL by allowing [endpoint_url](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-config-endpoint_url) to be specified in the AWS config file or by setting environment variable [AWS_ENDPOINT_URL](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list-AWS_ENDPOINT_URL). This makes it possible to use aws-vault with third party S3 storage providers such as [Wasabi](https://wasabi.com/) that support IAM but require a custom STS endpoint URL.