### PR TITLE
fix: AWS_ENDPOINT_URL not set

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -196,7 +196,7 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		subshellHelp = fmt.Sprintf("Starting subshell %s, use `exit` to exit the subshell", input.Command)
 	}
 
-	cmdEnv := createEnv(input.ProfileName, config.Region)
+	cmdEnv := createEnv(input.ProfileName, config.Region, config.EndpointURL)
 
 	if input.StartEc2Server {
 		if server.IsProxyRunning() {
@@ -249,7 +249,7 @@ func printToStderr(helpMsg string) {
 	fmt.Fprint(os.Stderr, helpMsg, "\n")
 }
 
-func createEnv(profileName string, region string) environ {
+func createEnv(profileName string, region string, endpointURL string) environ {
 	env := environ(os.Environ())
 	env.Unset("AWS_ACCESS_KEY_ID")
 	env.Unset("AWS_SECRET_ACCESS_KEY")
@@ -268,6 +268,11 @@ func createEnv(profileName string, region string) environ {
 		log.Printf("Setting subprocess env: AWS_REGION=%s, AWS_DEFAULT_REGION=%s", region, region)
 		env.Set("AWS_REGION", region)
 		env.Set("AWS_DEFAULT_REGION", region)
+	}
+
+	if endpointURL != "" {
+		log.Printf("Setting subprocess env: AWS_ENDPOINT_URL=%s", endpointURL)
+		env.Set("AWS_ENDPOINT_URL", endpointURL)
 	}
 
 	return env


### PR DESCRIPTION
This fixes bug #261 which was introduced in pull request #229 and sets the `AWS_ENDPOINT_URL` as an environment variable when using `aws-vault exec`.

Note that not all AWS config settings supported by AWS Vault result in the corresponding environment variable to be set by `aws-vault exec`. At the time of submitting pull request #229 it was not entirely clear which environment variables should be set and which one should not be set. Notably `AWS_STS_REGIONAL_ENDPOINTS` (which is also related to STS endpoint URL usage) is not set by `aws-vault exec` which makes it not entirely clear whether `AWS_ENDPOINT_URL` should be set.