### PR TITLE
feat: Add support for EUSC partition

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -238,6 +238,9 @@ func generateLoginURL(region string, path string) (string, string) {
 		case strings.HasPrefix(region, "us-gov-"):
 			loginURLPrefix = "https://signin.amazonaws-us-gov.com/federation"
 			destinationDomain = "console.amazonaws-us-gov.com"
+		case strings.HasPrefix(region, "eusc-"):
+			loginURLPrefix = "https://signin.amazonaws-eusc.eu/federation" // NOTE: not yet available for aws-eusc
+			destinationDomain = "console.amazonaws-eusc.eu"                // URL for console.aws.eu
 		}
 		if path != "" {
 			destination = fmt.Sprintf("https://%s.%s/%s?region=%s",


### PR DESCRIPTION
Add support for: https://aws.amazon.com/blogs/aws/opening-the-aws-european-sovereign-cloud/

and able to log in to: https://console.amazonaws-eusc.eu/console/home