### PR TITLE
fix: Enable FreeBSD builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,12 +43,12 @@ jobs:
             cc: powerpc64le-linux-gnu-gcc
             pkg: gcc-powerpc64le-linux-gnu
 
-          #- goos: freebsd
-          #  goarch: amd64
-          #  out: aws-vault-freebsd-amd64
-          #  cgo: "0"
-          #  cc: ""
-          #  pkg: ""
+          - goos: freebsd
+            goarch: amd64
+            out: aws-vault-freebsd-amd64
+            cgo: "0"
+            cc: ""
+            pkg: ""
 
           - goos: windows
             goarch: amd64
@@ -100,47 +100,48 @@ jobs:
           name: ${{ matrix.out }}
           path: ${{ matrix.out }}
 
-  build-windows:
-    if: startsWith(github.ref, 'refs/tags/x')
-    strategy:
-      matrix:
-        include:
-          - os: windows-latest
-            goos: winows
-            goarch: amd64
-            out: aws-vault-windows-amd64.exe
-          - os: windows-11-arm
-            goos: winows
-            goarch: arm64
-            out: aws-vault-windows-arm64.exe
+  # we can cross-compile on Linux
+  #build-windows:
+  #  if: startsWith(github.ref, 'refs/tags/x')
+  #  strategy:
+  #    matrix:
+  #      include:
+  #        - os: windows-latest
+  #          goos: winows
+  #          goarch: amd64
+  #          out: aws-vault-windows-amd64.exe
+  #        - os: windows-11-arm
+  #          goos: winows
+  #          goarch: arm64
+  #          out: aws-vault-windows-arm64.exe
 
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # disable shallow clone - get all
+  #  runs-on: ${{ matrix.os }}
+  #  steps:
+  #    - name: Checkout
+  #      uses: actions/checkout@v6
+  #      with:
+  #        fetch-depth: 0 # disable shallow clone - get all
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 'stable'
-          #go-version-file: 'go.mod'
-          check-latest: true
-        id: go
+  #    - name: Set up Go
+  #      uses: actions/setup-go@v6
+  #      with:
+  #        go-version: 'stable'
+  #        #go-version-file: 'go.mod'
+  #        check-latest: true
+  #      id: go
 
-      - name: Build
-        env:
-          GOOS: windows
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 1
-        run: |
-          make ${{ matrix.out }}
-      - uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.out }}
-          path: ${{ matrix.out }}
-          retention-days: 7
+  #    - name: Build
+  #      env:
+  #        GOOS: windows
+  #        GOARCH: ${{ matrix.goarch }}
+  #        CGO_ENABLED: 1
+  #      run: |
+  #        make ${{ matrix.out }}
+  #    - uses: actions/upload-artifact@v6
+  #      with:
+  #        name: ${{ matrix.out }}
+  #        path: ${{ matrix.out }}
+  #        retention-days: 7
 
   build-macos:
     runs-on: macos-latest

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
-	github.com/byteness/keyring v1.7.0
+	github.com/byteness/keyring v1.7.1
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK1
 github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 h1:j59wGsxaBk6aFBuuYofk2oznMGZYyzFovjDqavlJHM8=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0/go.mod h1:3FrDGTXj08zj6qtqlIvt0vS8eWNrrYpnXOEbcQgFmvM=
-github.com/byteness/keyring v1.7.0 h1:dfkJQiYlW5iaNJ2bwwQUG5H0Z3YDsEgEtz5K1uQsoyY=
-github.com/byteness/keyring v1.7.0/go.mod h1:j9xWRT9osBrA79IynSG4jK6SAl7/vXADzPDZTLkSVGs=
+github.com/byteness/keyring v1.7.1 h1:boksmVtuueSQbOtXVjMPNdsS5Q/qwLOkVjtExfW4za0=
+github.com/byteness/keyring v1.7.1/go.mod h1:j9xWRT9osBrA79IynSG4jK6SAl7/vXADzPDZTLkSVGs=
 github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=
 github.com/byteness/percent v0.2.2/go.mod h1:nwavge92FhIyfnldz4YWZD8uxPVvdh8NlzLRd1VYRDs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=


### PR DESCRIPTION
Resolves: #284 

* re-enable FreeBSD builds
* bump keyring dependency which disables OP backend builds on FreeBSD due missing upstream deps
* GHA workflow clean-up