### PR TITLE
feat: 1password desktop integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The supported vaulting backends are:
 * Encrypted file
 * [1Password Connect](https://developer.1password.com/docs/connect/)
 * [1Password Service Accounts](https://developer.1password.com/docs/service-accounts)
+* [1Password Desktop App](https://developer.1password.com/docs/sdks/desktop-app-integrations/)
 
 Use the `--backend` flag or `AWS_VAULT_BACKEND` environment variable to specify.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -288,6 +288,7 @@ To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_OP_CONNECT_HOST`: 1Password Connect server HTTP(S) URI (see the flag `--op-connect-host`)
 * `AWS_VAULT_OP_CONNECT_TOKEN`: 1Password Connect server access token
 * `AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN`: 1Password service account token
+* `AWS_VAULT_OP_DESKTOP_ACCOUNT_ID`: 1Password Desktop App account name or account UUID (see the flag `--op-desktop-account-id`)
 * `AWS_CONFIG_FILE`: The location of the AWS config file
 * `AWS_VAULT_STDOUT`: Print login URL to stdout instead of opening in default browser (see the flag `--stdout`)
 

--- a/cli/add.go
+++ b/cli/add.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/prompt"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 type AddCommandInput struct {

--- a/cli/global.go
+++ b/cli/global.go
@@ -28,6 +28,7 @@ var keyringConfigDefaults = keyring.Config{
 	WinCredPrefix:            "aws-vault",
 	OPConnectTokenEnv:        "AWS_VAULT_OP_CONNECT_TOKEN",
 	OPTokenEnv:               "AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN",
+	OPDesktopAccountID:       "AWS_VAULT_OP_DESKTOP_ACCOUNT_ID",
 	OPTokenFunc:              keyringPassphrasePrompt,
 }
 
@@ -191,6 +192,10 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 	app.Flag("op-connect-host", "1Password Connect server HTTP(S) URI").
 		Envar("AWS_VAULT_OP_CONNECT_HOST").
 		StringVar(&a.KeyringConfig.OPConnectHost)
+
+	app.Flag("op-desktop-account-id", "1Password Desktop App account name or account UUID").
+		Envar("AWS_VAULT_OP_DESKTOP_ACCOUNT_ID").
+		StringVar(&a.KeyringConfig.OPDesktopAccountID)
 
 	app.Flag("biometrics", "Use biometric authentication if supported").
 		Envar("AWS_VAULT_BIOMETRICS").


### PR DESCRIPTION
This PR enables use of 1Password’s Desktop Application Integration introduced in `onepassword-sdk-go`.

https://developer.1password.com/docs/sdks/desktop-app-integrations/

- ref
	- https://github.com/ByteNess/keyring/pull/56

## Usage

```
aws-vaul exec --backend=op-desktop --op-vault-id=<your-valult-id> --op-desktop-account-id=<your-desktop-account-id>
```

or 

```
export AWS_VAULT_BACKEND=op-desktop
export AWS_VAULT_OP_VAULT_ID=<your-valult-id>
export AWS_VAULT_OP_DESKTOP_ACCOUNT=<your-desktop-account-id>

aws-vaul exec 
```