### PR TITLE
feat(aws-vault-proxy): use multi-stage docker builds and static binary

### DIFF
--- a/contrib/_aws-vault-proxy/Dockerfile
+++ b/contrib/_aws-vault-proxy/Dockerfile
@@ -1,5 +1,9 @@
-FROM golang:1.17
-WORKDIR /usr/src/aws-vault-proxy
-COPY . /usr/src/aws-vault-proxy
-RUN go build -v -o /usr/local/bin/aws-vault-proxy ./...
-CMD ["/usr/local/bin/aws-vault-proxy"]
+FROM golang:alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o aws-vault-proxy
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/aws-vault-proxy /aws-vault-proxy
+CMD ["/aws-vault-proxy"]

--- a/contrib/_aws-vault-proxy/docker-compose.yml
+++ b/contrib/_aws-vault-proxy/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     networks:
       aws-vault:
         ipv4_address: "169.254.170.2" # This special IP address is recognized by the AWS SDKs and AWS CLI
-    healthcheck:
-      test: pgrep aws-vault-proxy
   testapp:
     image: amazon/aws-cli
     entrypoint: ""


### PR DESCRIPTION
this decreases the image size from ~970MB to ~10MB