### PR TITLE
fix(aws-vault-proxy): add a cli flag to check the running service

### DIFF
--- a/contrib/_aws-vault-proxy/Dockerfile
+++ b/contrib/_aws-vault-proxy/Dockerfile
@@ -6,4 +6,7 @@ RUN CGO_ENABLED=0 go build -o aws-vault-proxy
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/aws-vault-proxy /aws-vault-proxy
+
+# Use the same executable to send ourselves a http healthcheck
+HEALTHCHECK CMD ["/aws-vault-proxy", "-check-running"]
 CMD ["/aws-vault-proxy"]

--- a/contrib/_aws-vault-proxy/main.go
+++ b/contrib/_aws-vault-proxy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/gorilla/handlers"
 )
+
+var checkRunningFlag = flag.Bool("check-running", false, "check that the proxy is running and healthy")
 
 func GetReverseProxyTarget() *url.URL {
 	url, err := url.Parse(os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"))
@@ -26,7 +29,28 @@ func addAuthorizationHeader(authToken string, next http.Handler) http.HandlerFun
 	}
 }
 
+// Send a http request to a running instance on localhost,
+// any valid http response is a successful healthcheck
+func checkRunning() {
+	client := &http.Client{ Timeout: 15 * time.Second }
+
+	resp, err := client.Get("http://127.0.0.1/health")
+	if err != nil {
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	os.Exit(0)
+}
+
 func main() {
+	flag.Parse()
+	if *checkRunningFlag {
+		checkRunning()
+
+		return
+	}
+
 	target := GetReverseProxyTarget()
 	authToken := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN")
 	log.Printf("reverse proxying target:%s auth:%s\n", target, authToken)


### PR DESCRIPTION
now that we build the aws-vault-proxy docker image from **scratch**, the image doesn't contain pgrep, or curl or any other executables.

implement a healthcheck command in the same executable, that sends a http request to itself on localhost, and assume healthy for any http response. if the proxy process is stuck, then it'll become unhealthy.

can be tested by running:
```
docker compose kill --signal STOP aws-vault-proxy
```
which will make the container "stuck". docker will soon enough (after the default timeouts and retries) mark the service/container unhealthy.

Unstuck it with:
```
docker compose kill --signal CONT aws-vault-proxy
```