### PR TITLE
feat: add --profile-env flag to exec command

### DIFF
--- a/cli/clear.go
+++ b/cli/clear.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"fmt"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 type ClearCommandInput struct {

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -34,6 +34,7 @@ type ExecCommandInput struct {
 	NoSession        bool
 	UseStdout        bool
 	ShowHelpMessages bool
+	UseProfileEnv    bool
 }
 
 func (input ExecCommandInput) validate() error {
@@ -107,6 +108,9 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 	cmd.Flag("stdout", "Print the SSO link to the terminal without automatically opening the browser").
 		OverrideDefaultFromEnvar("AWS_VAULT_STDOUT").
 		BoolVar(&input.UseStdout)
+
+	cmd.Flag("profile-env", "Set AWS_PROFILE instead of injecting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY").
+		BoolVar(&input.UseProfileEnv)
 
 	cmd.Arg("profile", "Name of the profile").
 		//Required().
@@ -220,8 +224,20 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		}
 		printHelpMessage(subshellHelp, input.ShowHelpMessages)
 	} else {
-		if err = addCredsToEnv(credsProvider, input.ProfileName, &cmdEnv); err != nil {
-			return 0, err
+		if input.UseProfileEnv {
+			if _, err = credsProvider.Retrieve(context.TODO()); err != nil {
+				return 0, fmt.Errorf("Failed to get credentials for %s: %w", input.ProfileName, err)
+			}
+			if config.HasSSOStartURL() {
+				if err = vault.SyncOIDCTokenToStandardCache(config, keyring); err != nil {
+					log.Printf("Warning: failed to sync OIDC token to standard cache: %s", err)
+				}
+			}
+			cmdEnv.Set("AWS_PROFILE", input.ProfileName)
+		} else {
+			if err = addCredsToEnv(credsProvider, input.ProfileName, &cmdEnv); err != nil {
+				return 0, err
+			}
 		}
 		printHelpMessage(subshellHelp, input.ShowHelpMessages)
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -110,6 +110,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 		BoolVar(&input.UseStdout)
 
 	cmd.Flag("profile-env", "Set AWS_PROFILE instead of injecting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY").
+		OverrideDefaultFromEnvar("AWS_VAULT_PROFILE_ENV").
 		BoolVar(&input.UseProfileEnv)
 
 	cmd.Arg("profile", "Name of the profile").
@@ -225,8 +226,10 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		printHelpMessage(subshellHelp, input.ShowHelpMessages)
 	} else {
 		if input.UseProfileEnv {
+			// Validate credentials are accessible before setting AWS_PROFILE,
+			// so we fail fast rather than letting the child process fail silently.
 			if _, err = credsProvider.Retrieve(context.TODO()); err != nil {
-				return 0, fmt.Errorf("Failed to get credentials for %s: %w", input.ProfileName, err)
+				return 0, fmt.Errorf("failed to get credentials for %s: %w", input.ProfileName, err)
 			}
 			if config.HasSSOStartURL() {
 				if err = vault.SyncOIDCTokenToStandardCache(config, keyring); err != nil {

--- a/cli/list.go
+++ b/cli/list.go
@@ -7,9 +7,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 type ListCommandInput struct {

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/byteness/keyring"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/prompt"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 type RemoveCommandInput struct {

--- a/contrib/_aws-vault-proxy/main.go
+++ b/contrib/_aws-vault-proxy/main.go
@@ -32,7 +32,7 @@ func addAuthorizationHeader(authToken string, next http.Handler) http.HandlerFun
 // Send a http request to a running instance on localhost,
 // any valid http response is a successful healthcheck
 func checkRunning() {
-	client := &http.Client{ Timeout: 15 * time.Second }
+	client := &http.Client{Timeout: 15 * time.Second}
 
 	resp, err := client.Get("http://127.0.0.1/health")
 	if err != nil {

--- a/vault/config.go
+++ b/vault/config.go
@@ -114,7 +114,7 @@ func (c *ConfigFile) parseFile() error {
 		AllowNestedValues:    true,
 		InsensitiveSections:  false,
 		InsensitiveKeys:      true,
-		IgnoreInlineComment:  true,
+		SpaceBeforeInlineComment: true,
 	}, c.Path)
 	if err != nil {
 		return fmt.Errorf("Error parsing config file %s: %w", c.Path, err)

--- a/vault/config.go
+++ b/vault/config.go
@@ -111,9 +111,11 @@ func (c *ConfigFile) parseFile() error {
 	log.Printf("Parsing config file %s", c.Path)
 
 	f, err := ini.LoadSources(ini.LoadOptions{
-		AllowNestedValues:    true,
-		InsensitiveSections:  false,
-		InsensitiveKeys:      true,
+		AllowNestedValues:   true,
+		InsensitiveSections: false,
+		InsensitiveKeys:     true,
+		// Require a space before '#' to treat it as an inline comment.
+		// Without this, '#' in values like sso_start_url is stripped.
 		SpaceBeforeInlineComment: true,
 	}, c.Path)
 	if err != nil {

--- a/vault/config.go
+++ b/vault/config.go
@@ -111,9 +111,10 @@ func (c *ConfigFile) parseFile() error {
 	log.Printf("Parsing config file %s", c.Path)
 
 	f, err := ini.LoadSources(ini.LoadOptions{
-		AllowNestedValues:   true,
-		InsensitiveSections: false,
-		InsensitiveKeys:     true,
+		AllowNestedValues:    true,
+		InsensitiveSections:  false,
+		InsensitiveKeys:      true,
+		IgnoreInlineComment:  true,
 	}, c.Path)
 	if err != nil {
 		return fmt.Errorf("Error parsing config file %s: %w", c.Path, err)

--- a/vault/credentialkeyring.go
+++ b/vault/credentialkeyring.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/byteness/keyring"
 )
 
 type CredentialKeyring struct {

--- a/vault/oidctokenkeyring.go
+++ b/vault/oidctokenkeyring.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	"github.com/byteness/keyring"
 )
 
 type OIDCTokenKeyring struct {

--- a/vault/sessionkeyring.go
+++ b/vault/sessionkeyring.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/byteness/keyring"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/byteness/keyring"
 )
 
 var sessionKeyPattern = regexp.MustCompile(`^(?P<type>[^,]+),(?P<profile>[^,]+),(?P<mfaSerial>[^,]*),(?P<expiration>[0-9]{1,})$`)

--- a/vault/ssorolecredentialsprovider.go
+++ b/vault/ssorolecredentialsprovider.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/byteness/keyring"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
@@ -17,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 	ssooidctypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/byteness/keyring"
 	"github.com/skratchdot/open-golang/open"
 )
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -2,12 +2,15 @@ package vault
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -32,7 +35,7 @@ func NewAwsConfig(region, stsRegionalEndpoints, endpointURL string) aws.Config {
 func NewAwsConfigWithCredsProvider(credsProvider aws.CredentialsProvider, region, stsRegionalEndpoints, endpointURL string) aws.Config {
 	return aws.Config{
 		Region:                      region,
-		Credentials:                 credsProvider,
+		Credentials:                 aws.NewCredentialsCache(credsProvider),
 		EndpointResolverWithOptions: getSTSEndpointResolver(stsRegionalEndpoints, endpointURL),
 	}
 }
@@ -165,6 +168,84 @@ func NewSSORoleCredentialsProvider(k keyring.Keyring, config *ProfileConfig, use
 	}
 
 	return ssoRoleCredentialsProvider, nil
+}
+
+// ssoTokenCacheKey returns the key used to compute the standard SSO cache file path.
+// For profiles using [sso-session] this is the session name; for legacy profiles it is the start URL.
+func ssoTokenCacheKey(config *ProfileConfig) string {
+	if config.SSOSession != "" {
+		return config.SSOSession
+	}
+	return config.SSOStartURL
+}
+
+// NewStandardCachedSSOCredentialsProvider returns an ssocreds.Provider that reads the SSO
+// access token from the standard AWS CLI cache file (~/.aws/sso/cache/<sha1>.json).
+// Returns nil, nil if the standard token file does not exist.
+func NewStandardCachedSSOCredentialsProvider(config *ProfileConfig) (aws.CredentialsProvider, error) {
+	tokenFilepath, err := ssocreds.StandardCachedTokenFilepath(ssoTokenCacheKey(config))
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(tokenFilepath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	cfg := NewAwsConfig(config.SSORegion, config.STSRegionalEndpoints, config.EndpointURL)
+
+	return ssocreds.New(
+		sso.NewFromConfig(cfg),
+		config.SSOAccountID,
+		config.SSORoleName,
+		config.SSOStartURL,
+		func(o *ssocreds.Options) {
+			o.CachedTokenFilepath = tokenFilepath
+		},
+	), nil
+}
+
+// SyncOIDCTokenToStandardCache writes the OIDC access token for the given profile
+// from the keyring to the standard AWS SSO cache file (~/.aws/sso/cache/<sha1>.json),
+// so that other AWS tools that read the standard file location can use it.
+// Returns nil without error if the standard cache file already exists.
+func SyncOIDCTokenToStandardCache(config *ProfileConfig, k keyring.Keyring) error {
+	tokenFilepath, err := ssocreds.StandardCachedTokenFilepath(ssoTokenCacheKey(config))
+	if err != nil {
+		return err
+	}
+
+	token, err := (OIDCTokenKeyring{Keyring: k}).Get(config.SSOStartURL)
+	if err != nil {
+		return fmt.Errorf("OIDC token not found in keyring for %s: %w", config.SSOStartURL, err)
+	}
+
+	expiration := time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+
+	type cachedToken struct {
+		AccessToken  string `json:"accessToken"`
+		ExpiresAt    string `json:"expiresAt"`
+		RefreshToken string `json:"refreshToken,omitempty"`
+	}
+
+	t := cachedToken{
+		AccessToken: aws.ToString(token.AccessToken),
+		ExpiresAt:   expiration.UTC().Format(time.RFC3339),
+	}
+	if token.RefreshToken != nil {
+		t.RefreshToken = aws.ToString(token.RefreshToken)
+	}
+
+	b, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(tokenFilepath), 0700); err != nil {
+		return err
+	}
+
+	return os.WriteFile(tokenFilepath, b, 0600)
 }
 
 // NewCredentialProcessProvider creates a provider to retrieve credentials from an external

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -216,11 +216,16 @@ func SyncOIDCTokenToStandardCache(config *ProfileConfig, k keyring.Keyring) erro
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(tokenFilepath), 0700); err != nil {
-		return err
-	}
+	// MkdirAll only sets perms when creating the directory. If
+    // ~/.aws/sso/cache already exists with looser permissions (e.g. 0755
+    // from a prior AWS CLI run), we intentionally do not tighten them here
+    // — changing directory perms out from under another tool would be
+    // surprising. The token file itself is written 0600 below.
+    if err := os.MkdirAll(filepath.Dir(tokenFilepath), 0700); err != nil {
+    	return err
+    }
 
-	return os.WriteFile(tokenFilepath, b, 0600)
+    return writeFileAtomic(tokenFilepath, b, 0600)
 }
 
 // writeFileAtomic writes data to filename atomically by first writing to a

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -223,6 +223,67 @@ func SyncOIDCTokenToStandardCache(config *ProfileConfig, k keyring.Keyring) erro
 	return os.WriteFile(tokenFilepath, b, 0600)
 }
 
+// writeFileAtomic writes data to filename atomically by first writing to a
+// temporary file in the same directory and then renaming it into place.
+// The temp file is created with mode 0600 and fsync'd before the rename so
+// that a crash or concurrent writer cannot leave a partial or corrupt file
+// at the destination — readers either see the old contents or the new,
+// never a half-written mix.
+//
+// The temp file is created in the same directory as filename to guarantee
+// that os.Rename is atomic (rename(2) is only atomic within a single
+// filesystem; /tmp is often on a different one).
+//
+// Note: this does not tighten permissions on an existing parent directory.
+// Callers that need 0700 on the directory must enforce that separately,
+// and should be aware that os.MkdirAll is a no-op (including on perms) if
+// the directory already exists.
+func writeFileAtomic(filename string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(filename)
+
+	f, err := os.CreateTemp(dir, filepath.Base(filename)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := f.Name()
+
+	// Best-effort cleanup if we bail out before the rename succeeds.
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	// CreateTemp defaults to 0600 on Unix, but be explicit — umask and
+	// platform behavior vary, and this file holds a bearer token.
+	if err = f.Chmod(perm); err != nil {
+		f.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+
+	if _, err = f.Write(data); err != nil {
+		f.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	// fsync before rename so the contents are durable on disk before any
+	// reader can observe the new inode at the target path.
+	if err = f.Sync(); err != nil {
+		f.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpName, filename); err != nil {
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+
+	return nil
+}
+
 // NewCredentialProcessProvider creates a provider to retrieve credentials from an external
 // executable as described in https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
 func NewCredentialProcessProvider(k keyring.Keyring, config *ProfileConfig, useSessionCache bool) (aws.CredentialsProvider, error) {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -35,7 +35,7 @@ func NewAwsConfig(region, stsRegionalEndpoints, endpointURL string) aws.Config {
 func NewAwsConfigWithCredsProvider(credsProvider aws.CredentialsProvider, region, stsRegionalEndpoints, endpointURL string) aws.Config {
 	return aws.Config{
 		Region:                      region,
-		Credentials:                 aws.NewCredentialsCache(credsProvider),
+		Credentials:                 credsProvider,
 		EndpointResolverWithOptions: getSTSEndpointResolver(stsRegionalEndpoints, endpointURL),
 	}
 }
@@ -179,36 +179,9 @@ func ssoTokenCacheKey(config *ProfileConfig) string {
 	return config.SSOStartURL
 }
 
-// NewStandardCachedSSOCredentialsProvider returns an ssocreds.Provider that reads the SSO
-// access token from the standard AWS CLI cache file (~/.aws/sso/cache/<sha1>.json).
-// Returns nil, nil if the standard token file does not exist.
-func NewStandardCachedSSOCredentialsProvider(config *ProfileConfig) (aws.CredentialsProvider, error) {
-	tokenFilepath, err := ssocreds.StandardCachedTokenFilepath(ssoTokenCacheKey(config))
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := os.Stat(tokenFilepath); os.IsNotExist(err) {
-		return nil, nil
-	}
-
-	cfg := NewAwsConfig(config.SSORegion, config.STSRegionalEndpoints, config.EndpointURL)
-
-	return ssocreds.New(
-		sso.NewFromConfig(cfg),
-		config.SSOAccountID,
-		config.SSORoleName,
-		config.SSOStartURL,
-		func(o *ssocreds.Options) {
-			o.CachedTokenFilepath = tokenFilepath
-		},
-	), nil
-}
-
 // SyncOIDCTokenToStandardCache writes the OIDC access token for the given profile
 // from the keyring to the standard AWS SSO cache file (~/.aws/sso/cache/<sha1>.json),
 // so that other AWS tools that read the standard file location can use it.
-// Returns nil without error if the standard cache file already exists.
 func SyncOIDCTokenToStandardCache(config *ProfileConfig, k keyring.Keyring) error {
 	tokenFilepath, err := ssocreds.StandardCachedTokenFilepath(ssoTokenCacheKey(config))
 	if err != nil {
@@ -220,6 +193,8 @@ func SyncOIDCTokenToStandardCache(config *ProfileConfig, k keyring.Keyring) erro
 		return fmt.Errorf("OIDC token not found in keyring for %s: %w", config.SSOStartURL, err)
 	}
 
+	// ExpiresIn is recalculated by OIDCTokenKeyring.Get() to reflect the
+	// remaining seconds until expiry, so time.Now().Add() is correct here.
 	expiration := time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
 
 	type cachedToken struct {

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/byteness/keyring"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 func TestUsageWebIdentityExample(t *testing.T) {

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/byteness/keyring"
 )
 
+func TestWriteFileAtomic_NoPartialOnCrash(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "token.json")
+
+	// Seed with known-good content.
+	if err := os.WriteFile(target, []byte(`{"ok":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write new content atomically.
+	if err := writeFileAtomic(target, []byte(`{"ok":false,"new":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// No stray temp files left behind.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 file, got %d: %v", len(entries), entries)
+	}
+
+	// Perms are 0600.
+	info, _ := os.Stat(target)
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("perm = %o, want 0600", info.Mode().Perm())
+	}
+}
+
 func TestUsageWebIdentityExample(t *testing.T) {
 	f := newConfigFile(t, []byte(`
 [profile role2]


### PR DESCRIPTION
This change adds a `--profile-env` flag to the `exec` command in order to allow profile-based SDK calls to authenticate. Setting `--profile-env` will cause a token file to be created (default is `~/.aws/sso/cache`) with a filename that matches the sha1 of the start URL. My startURL value has a hash symbol in it so the IgnoreInlineComment option needs to be passed so it won't strip it out of the string value. This is needed in order to generate the correct SHA1. When `--profile-env` is set, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set in the environment and instead AWS_PROFILE is set to a value that matches the profile that was passed in at the CLI. If the tokenfile is being used for auth, it is checked for expiration and it is refreshed if needed.

* co-written by claude code
* Tested both with and without --profile-env flag being set