### PR TITLE
fix: yubikey prompts for AWS and kubectl

### DIFF
--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -35,7 +35,22 @@ func YkmanMfaProvider(mfaSerial string) (string, error) {
 
 	log.Printf("Fetching MFA code using `ykman %s`", strings.Join(args, " "))
 	cmd := exec.Command("ykman", args...)
-	cmd.Stderr = os.Stderr
+
+	// Open the controlling TTY read-write so that:
+	//   - Stderr: the "Touch your YubiKey..." prompt is visible even when
+	//     aws-vault is spawned as a credential_process subprocess (where the
+	//     parent process may capture os.Stderr via a pipe).
+	//   - Stdin: ykman gets a real TTY as stdin so sys.stdin.isatty() == True,
+	//     allowing interactive prompts (e.g. OATH password) to work even when
+	//     aws-vault's stdin is a pipe (e.g. docker credential helper).
+	ttyFile, _ := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	defer ttyFile.Close()
+	if ttyFile != nil {
+		cmd.Stdin = ttyFile
+		cmd.Stderr = ttyFile
+	} else {
+		cmd.Stderr = os.Stderr
+	}
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/vault/mfa_unix.go
+++ b/vault/mfa_unix.go
@@ -12,7 +12,23 @@ import (
 
 func executeMFACommand(processCmd string) (string, error) {
 	cmd := exec.Command("/bin/sh", "-c", processCmd)
-	cmd.Stderr = os.Stderr
+
+	// Open the controlling TTY read-write so that:
+	//   - Stderr: interactive prompts (e.g. "Touch your YubiKey...") are
+	//     visible even when aws-vault's stderr is captured by the parent
+	//     process (e.g. aws CLI or kubectl using credential_process).
+	//   - Stdin: subprocess gets a real TTY as stdin so that tools like ykman
+	//     see sys.stdin.isatty() == True and can display interactive prompts
+	//     (e.g. OATH password) even when aws-vault's stdin is a pipe
+	//     (e.g. docker credential helper receiving JSON on stdin).
+	ttyFile, _ := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	defer ttyFile.Close()
+	if ttyFile != nil {
+		cmd.Stdin = ttyFile
+		cmd.Stderr = ttyFile
+	} else {
+		cmd.Stderr = os.Stderr
+	}
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/vault/mfa_unix_test.go
+++ b/vault/mfa_unix_test.go
@@ -1,0 +1,79 @@
+//go:build linux || darwin || freebsd || openbsd
+// +build linux darwin freebsd openbsd
+
+package vault_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/byteness/aws-vault/v7/vault"
+)
+
+// TestProcessMfaProvider_CapturesStdout verifies that stdout from the mfa_process
+// command is correctly captured and returned.
+func TestProcessMfaProvider_CapturesStdout(t *testing.T) {
+	token, err := vault.ProcessMfaProvider("echo '123456'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "123456" {
+		t.Errorf("got %q, want %q", token, "123456")
+	}
+}
+
+// TestProcessMfaProvider_TrimsWhitespace verifies that surrounding whitespace and
+// newlines are stripped from the captured output.
+func TestProcessMfaProvider_TrimsWhitespace(t *testing.T) {
+	token, err := vault.ProcessMfaProvider("printf '  123456  \\n'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "123456" {
+		t.Errorf("got %q, want %q", token, "123456")
+	}
+}
+
+// TestProcessMfaProvider_StderrNotCaptured verifies that stderr output from the
+// mfa_process command is not mixed into the captured stdout. This is the core
+// behaviour that allows tools like ykman to write "Touch your YubiKey..." to
+// the terminal without corrupting the MFA token returned to aws-vault.
+func TestProcessMfaProvider_StderrNotCaptured(t *testing.T) {
+	token, err := vault.ProcessMfaProvider("echo 'correct_token'; echo 'stderr_noise' >&2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "correct_token" {
+		t.Errorf("stderr leaked into captured output: got %q, want %q", token, "correct_token")
+	}
+}
+
+// TestProcessMfaProvider_CommandFailure verifies that a non-zero exit code from
+// the mfa_process command is propagated as an error.
+func TestProcessMfaProvider_CommandFailure(t *testing.T) {
+	_, err := vault.ProcessMfaProvider("exit 1")
+	if err == nil {
+		t.Fatal("expected error for failing command, got nil")
+	}
+}
+
+// TestProcessMfaProvider_StdinIsTTY verifies that the mfa_process command receives
+// a real TTY as stdin when /dev/tty is available. This is required for tools like
+// ykman that check sys.stdin.isatty() to decide how to display interactive prompts
+// (e.g. OATH password entry). Without this, the prompt silently fails when aws-vault
+// is used as a docker credential helper, because docker pipes JSON to aws-vault's
+// stdin and that pipe propagates down to the subprocess.
+func TestProcessMfaProvider_StdinIsTTY(t *testing.T) {
+	if f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err != nil {
+		t.Skip("no controlling terminal available (/dev/tty inaccessible), skipping TTY stdin test")
+	} else {
+		f.Close()
+	}
+
+	// test -t 0 exits 0 if fd 0 (stdin) is a terminal, non-zero otherwise.
+	_, err := vault.ProcessMfaProvider("test -t 0")
+	if err != nil {
+		t.Error("mfa_process command should receive a TTY as stdin when /dev/tty is available; " +
+			"interactive prompts (e.g. ykman OATH password) will fail otherwise")
+	}
+}

--- a/vault/mfa_windows.go
+++ b/vault/mfa_windows.go
@@ -17,7 +17,24 @@ func executeMFACommand(processCmd string) (string, error) {
 	shell := os.Getenv("SystemRoot") + "\\System32\\cmd.exe"
 	cmd := exec.Command(shell)
 	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "/C \"" + processCmd + "\""}
-	cmd.Stderr = os.Stderr
+	// Connect stdin to the console so that interactive prompts (e.g. OATH
+	// password) work even when aws-vault's stdin is a pipe (e.g. docker
+	// credential helper receiving JSON on stdin).
+	inFile, _ := os.OpenFile("CONIN$", os.O_RDONLY, 0)
+	defer inFile.Close()
+	if inFile != nil {
+		cmd.Stdin = inFile
+	}
+	// Connect stderr to the console so interactive prompts (e.g. "Touch your
+	// YubiKey...") are visible even when aws-vault's stderr is captured by the
+	// parent process.
+	outFile, _ := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+	defer outFile.Close()
+	if outFile != nil {
+		cmd.Stderr = outFile
+	} else {
+		cmd.Stderr = os.Stderr
+	}
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/vault/mfa_windows_test.go
+++ b/vault/mfa_windows_test.go
@@ -1,0 +1,91 @@
+//go:build windows
+// +build windows
+
+package vault_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/byteness/aws-vault/v7/vault"
+)
+
+// TestProcessMfaProvider_CapturesStdout verifies that stdout from the
+// mfa_process command is correctly captured and returned.
+func TestProcessMfaProvider_CapturesStdout(t *testing.T) {
+	token, err := vault.ProcessMfaProvider("echo 123456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "123456" {
+		t.Errorf("got %q, want %q", token, "123456")
+	}
+}
+
+// TestProcessMfaProvider_TrimsWhitespace verifies that surrounding whitespace
+// and Windows CRLF line endings are stripped from the captured output.
+// cmd.exe echo appends \r\n; leading spaces appear when the token is
+// preceded by spaces in the echo argument.
+func TestProcessMfaProvider_TrimsWhitespace(t *testing.T) {
+	token, err := vault.ProcessMfaProvider("echo   123456   ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "123456" {
+		t.Errorf("got %q, want %q", token, "123456")
+	}
+}
+
+// TestProcessMfaProvider_StderrNotCaptured verifies that stderr output from
+// the mfa_process command is not mixed into the captured stdout. This is the
+// core behaviour that allows tools like ykman to write "Touch your YubiKey..."
+// to the console without corrupting the MFA token returned to aws-vault.
+func TestProcessMfaProvider_StderrNotCaptured(t *testing.T) {
+	token, err := vault.ProcessMfaProvider(
+		"echo correct_token & echo noise 1>&2",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "correct_token" {
+		t.Errorf("stderr leaked into captured output: got %q, want %q",
+			token, "correct_token")
+	}
+}
+
+// TestProcessMfaProvider_CommandFailure verifies that a non-zero exit code
+// from the mfa_process command is propagated as an error.
+func TestProcessMfaProvider_CommandFailure(t *testing.T) {
+	_, err := vault.ProcessMfaProvider("exit 1")
+	if err == nil {
+		t.Fatal("expected error for failing command, got nil")
+	}
+}
+
+// TestProcessMfaProvider_StdinIsConsole verifies that the mfa_process command
+// receives the console as stdin when CONIN$ is available. This is required for
+// tools like ykman that check whether stdin is interactive before displaying
+// prompts (e.g. OATH password entry). Without this, the prompt silently fails
+// when aws-vault is used as a docker credential helper, because docker pipes
+// JSON to aws-vault's stdin and that pipe propagates down to the subprocess.
+func TestProcessMfaProvider_StdinIsConsole(t *testing.T) {
+	if f, err := os.OpenFile("CONIN$", os.O_RDONLY, 0); err != nil {
+		t.Skip("console input not available (CONIN$ inaccessible), " +
+			"skipping console stdin test")
+	} else {
+		f.Close()
+	}
+
+	// PowerShell [Console]::IsInputRedirected returns True when stdin is a
+	// pipe or file, False when it is the real console. Exit 1 on redirect so
+	// the test fails if stdin was not wired to CONIN$.
+	_, err := vault.ProcessMfaProvider(
+		`powershell -NonInteractive -Command ` +
+			`"if ([Console]::IsInputRedirected) { exit 1 }"`,
+	)
+	if err != nil {
+		t.Error("mfa_process command should receive the console as stdin " +
+			"when CONIN$ is available; interactive prompts " +
+			"(e.g. ykman OATH password) will fail otherwise")
+	}
+}


### PR DESCRIPTION
Fixes #160.

I used Claude Code to fix this bug. Tested on macOS 15.6.1 and Debian forky/sid. I don't have a Windows machine available to test there, hopefully someone else can verify that works.

Here is Claude's summary of the fix:

When aws-vault is used as a credential_process subprocess, the parent process (aws CLI, kubectl, docker, terraform) pipes stdout to capture the JSON credentials output. Some tools also capture stderr. Docker's credential helper protocol additionally pipes JSON to aws-vault's stdin, which propagates down when aws-vault spawns its mfa_process command.

Root cause: executeMFACommand (vault/mfa_unix.go) and YkmanMfaProvider (prompt/ykman.go) both inherited aws-vault's file descriptors without modification. With stderr captured by the parent, the "Touch your YubiKey..." prompt was invisible. With stdin piped from docker, ykman's sys.stdin.isatty() returned False, causing its click_prompt helper to attempt a readline() from the pipe (returning EOF), then fall through to click.prompt() which failed with exit code 1.

Fix: open /dev/tty with O_RDWR and assign it as both cmd.Stdin and cmd.Stderr for the subprocess. This ensures:

- The touch prompt is always visible on the real terminal regardless of how the parent process wired up aws-vault's stderr.
- The subprocess always sees a real TTY as stdin, so ykman's sys.stdin.isatty() returns True and interactive prompts (e.g. OATH password entry) work correctly in all calling contexts.
- No terminal mode (termios) manipulation occurs, so the fix does not disrupt callers that already work (terraform, bare shell).
- Falls back to os.Stderr if /dev/tty is unavailable.

The Windows equivalent (vault/mfa_windows.go) opens CONIN$ for stdin and CONOUT$ for stderr separately, as Windows does not have a single read-write console device node.

Files changed:
- vault/mfa_unix.go: O_WRONLY -> O_RDWR, add cmd.Stdin = ttyFile
- vault/mfa_windows.go: add CONIN$ open for cmd.Stdin
- prompt/ykman.go: same O_RDWR + cmd.Stdin change as mfa_unix.go

Tests added (vault/mfa_unix_test.go):
- CapturesStdout: stdout from mfa_process is returned as the token
- TrimsWhitespace: surrounding whitespace/newlines are stripped
- StderrNotCaptured: stderr does not bleed into the captured token
- CommandFailure: non-zero exit code is returned as an error
- StdinIsTTY: subprocess stdin is a TTY when /dev/tty is available; skipped automatically in headless CI environments