### PR TITLE
refactor(list): extract listRow and listCommandOutput

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -11,6 +12,44 @@ import (
 	"github.com/byteness/aws-vault/v7/vault"
 	"github.com/byteness/keyring"
 )
+
+// listRow holds the display values for one output row.
+// Empty string fields are rendered as "-" by writeTo.
+type listRow struct {
+	Profile     string
+	Credentials string
+	Sessions    string
+}
+
+// display returns s, or "-" if s is empty.
+func (r listRow) display(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func (r listRow) writeTo(w io.Writer) {
+	fmt.Fprintf(w, "%s\t%s\t%s\t\n",
+		r.display(r.Profile),
+		r.display(r.Credentials),
+		r.display(r.Sessions),
+	)
+}
+
+// listCommandOutput holds all rows to display in the table.
+type listCommandOutput struct {
+	Rows []listRow
+}
+
+func (o listCommandOutput) writeTo(w io.Writer) {
+	fmt.Fprintln(w, "Profile\tCredentials\tSessions\t")
+	fmt.Fprintln(w, "=======\t===========\t========\t")
+
+	for _, r := range o.Rows {
+		r.writeTo(w)
+	}
+}
 
 type ListCommandInput struct {
 	OnlyProfiles    bool
@@ -125,14 +164,11 @@ func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyrin
 
 	displayedSessionLabels := []string{}
 
-	w := tabwriter.NewWriter(os.Stdout, 25, 4, 2, ' ', 0)
-
-	fmt.Fprintln(w, "Profile\tCredentials\tSessions\t")
-	fmt.Fprintln(w, "=======\t===========\t========\t")
+	var rows []listRow
 
 	// list out known profiles first
 	for _, profileName := range awsConfigFile.ProfileNames() {
-		fmt.Fprintf(w, "%s\t", profileName)
+		row := listRow{Profile: profileName}
 
 		hasCred, err := credentialKeyring.Has(profileName)
 		if err != nil {
@@ -140,9 +176,7 @@ func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyrin
 		}
 
 		if hasCred {
-			fmt.Fprintf(w, "%s\t", profileName)
-		} else {
-			fmt.Fprintf(w, "-\t")
+			row.Credentials = profileName
 		}
 
 		var sessionLabels []string
@@ -162,11 +196,10 @@ func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyrin
 		}
 
 		if len(sessionLabels) > 0 {
-			fmt.Fprintf(w, "%s\t\n", strings.Join(sessionLabels, ", "))
-		} else {
-			fmt.Fprintf(w, "-\t\n")
+			row.Sessions = strings.Join(sessionLabels, ", ")
 		}
 
+		rows = append(rows, row)
 		displayedSessionLabels = append(displayedSessionLabels, sessionLabels...)
 	}
 
@@ -174,15 +207,18 @@ func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyrin
 	for _, credentialName := range credentialsNames {
 		_, ok := awsConfigFile.ProfileSection(credentialName)
 		if !ok {
-			fmt.Fprintf(w, "-\t%s\t-\t\n", credentialName)
+			rows = append(rows, listRow{Credentials: credentialName})
 		}
 	}
 
 	// show sessions that don't have profiles
 	sessionsWithoutProfiles := stringslice(allSessionLabels).remove(displayedSessionLabels)
 	for _, s := range sessionsWithoutProfiles {
-		fmt.Fprintf(w, "-\t-\t%s\t\n", s)
+		rows = append(rows, listRow{Sessions: s})
 	}
 
+	w := tabwriter.NewWriter(os.Stdout, 25, 4, 2, ' ', 0)
+	o := listCommandOutput{Rows: rows}
+	o.writeTo(w)
 	return w.Flush()
 }

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
-	"github.com/alecthomas/kingpin/v2"
+	"bytes"
+	"testing"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/keyring"
 )
 
@@ -19,4 +21,56 @@ func ExampleListCommand() {
 
 	// Output:
 	// llamas
+}
+
+func TestListRowWriteTo(t *testing.T) {
+	tests := []struct {
+		name     string
+		row      listRow
+		expected string
+	}{
+		{
+			name:     "full row",
+			row:      listRow{Profile: "admin", Credentials: "admin", Sessions: "sts.AssumeRole:1h0m0s"},
+			expected: "admin\tadmin\tsts.AssumeRole:1h0m0s\t\n",
+		},
+		{
+			name:     "empty fields render as dash",
+			row:      listRow{Profile: "admin"},
+			expected: "admin\t-\t-\t\n",
+		},
+		{
+			name:     "orphan credential",
+			row:      listRow{Credentials: "admin"},
+			expected: "-\tadmin\t-\t\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			tc.row.writeTo(&buf)
+			if got := buf.String(); got != tc.expected {
+				t.Errorf("writeTo() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestListCommandOutputWriteTo(t *testing.T) {
+	rows := []listRow{
+		{Profile: "admin", Credentials: "admin", Sessions: "sts.AssumeRole:1h0m0s"},
+		{Profile: "dev"},
+	}
+	var buf bytes.Buffer
+	listCommandOutput{Rows: rows}.writeTo(&buf)
+
+	want := "Profile\tCredentials\tSessions\t\n" +
+		"=======\t===========\t========\t\n" +
+		"admin\tadmin\tsts.AssumeRole:1h0m0s\t\n" +
+		"dev\t-\t-\t\n"
+
+	if got := buf.String(); got != want {
+		t.Errorf("writeTo() = %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

Pure refactor of `cli/list.go` — no functional change.

Extracts the inline rendering logic in `ListCommand` into two small structs:

- `listRow` — holds one output row; renders empty fields as `"-"`
- `listCommandOutput` — holds all rows; writes header + rows to an `io.Writer`

Adds unit tests for both structs.

### AI Disclosure

This PR was developed with AI assistance (GitHub Copilot)
All code has been reviewed, edited, and manually verified by the author.

Related: #364 