### PR TITLE
fix(vault): only prime GetSessionToken for genuine role chaining

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -370,9 +370,23 @@ func (t *TempCredentialsCreator) getSourceCreds(config *ProfileConfig, hasStored
 	return nil, fmt.Errorf("profile %s: credentials missing", config.ProfileName)
 }
 
+func rolesInChain(config *ProfileConfig) int {
+	count := 0
+	for c := config; c != nil; c = c.ChainedFromProfile {
+		if c.HasRole() {
+			count++
+		}
+	}
+	return count
+}
+
 func (t *TempCredentialsCreator) primeWithGetSessionToken(config *ProfileConfig, sourcecredsProvider aws.CredentialsProvider) (aws.CredentialsProvider, bool, error) {
-	isSourceForRoleProfile := config.ChainedFromProfile != nil && config.ChainedFromProfile.HasRole()
-	shouldPrime := !config.HasRole() || isSourceForRoleProfile
+	// IMPORTANT:
+	// GetSessionToken priming carries a single MFA authentication across the chain, but any AssumeRole made from the resulting session token is itself limited to 1h by AWS. So only prime when priming is actually needed:
+	//   - exactly one role in the chain: a direct role login. AssumeRole straight from the long-term credentials so the role's full max session duration is available. Do NOT prime.
+	//   - zero roles: the session token itself is the deliverable.
+	//   - two or more roles: genuine role chaining. Prime once so MFA is entered a single time. Each chained AssumeRole is then capped to 1h with capAssumeRoleDurationIfChained.
+	shouldPrime := rolesInChain(config) != 1
 	if !shouldPrime || !isMasterCredentialsProvider(sourcecredsProvider) {
 		return sourcecredsProvider, true, nil
 	}

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -415,6 +415,63 @@ mfa_serial=arn:aws:iam::111111111111:mfa/user
 	}
 }
 
+// Ensures a single-role login from a non-role MFA source profile keeps its requested duration without GetSessionToken priming (#290).
+func TestSourceProfileRoleLoginDoesNotCapAssumeRoleDuration(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[profile source]
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+
+[profile target]
+source_profile=source
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+role_arn=arn:aws:iam::111111111111:role/target
+`))
+	defer os.Remove(f)
+
+	base := vault.ProfileConfig{
+		AssumeRoleDuration:             12 * time.Hour,
+		ChainedGetSessionTokenDuration: 12 * time.Hour,
+	}
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := vault.NewConfigLoader(base, configFile, "target")
+	config, err := configLoader.GetProfileConfig("target")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	config.MfaToken = "123456"
+	config.SourceProfile.MfaToken = "123456"
+
+	ckr := newSeededKeyring(t, "source")
+
+	buf := captureLogs(t)
+
+	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Single role in the chain -> assumed directly from long-term creds -> full duration kept.
+	if config.AssumeRoleDuration != 12*time.Hour {
+		t.Fatalf("expected target AssumeRole duration to remain %s, got %s", 12*time.Hour, config.AssumeRoleDuration)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "using GetSessionToken") {
+		t.Fatalf("did not expect GetSessionToken for a direct (single-role) login, logs:\n%s", logs)
+	}
+	if strings.Contains(logs, "profile target: capping AssumeRole duration") {
+		t.Fatalf("did not expect target AssumeRole to be capped, logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "profile target: using AssumeRole (with MFA)") {
+		t.Fatalf("expected target to use a direct AssumeRole (with MFA), logs:\n%s", logs)
+	}
+}
+
 // newSeededKeyring returns a CredentialKeyring with a single set of stub
 // credentials stored under the given profile name. Pass an empty name to get
 // an empty keyring.

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -472,6 +472,140 @@ role_arn=arn:aws:iam::111111111111:role/target
 	}
 }
 
+// Ensures a single-role login behind a non-role alias profile keeps its requested duration without GetSessionToken priming.
+func TestAliasedSourceProfileRoleLoginDoesNotCapAssumeRoleDuration(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[profile source]
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+
+[profile alias]
+source_profile=source
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+
+[profile target]
+source_profile=alias
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+role_arn=arn:aws:iam::111111111111:role/target
+`))
+	defer os.Remove(f)
+
+	base := vault.ProfileConfig{
+		AssumeRoleDuration:             12 * time.Hour,
+		ChainedGetSessionTokenDuration: 12 * time.Hour,
+	}
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := vault.NewConfigLoader(base, configFile, "target")
+	config, err := configLoader.GetProfileConfig("target")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	config.MfaToken = "123456"
+	config.SourceProfile.MfaToken = "123456"
+	config.SourceProfile.SourceProfile.MfaToken = "123456"
+
+	ckr := newSeededKeyring(t, "source")
+
+	buf := captureLogs(t)
+
+	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Still a single role in the chain -> assumed directly from long-term creds -> full duration kept.
+	if config.AssumeRoleDuration != 12*time.Hour {
+		t.Fatalf("expected target AssumeRole duration to remain %s, got %s", 12*time.Hour, config.AssumeRoleDuration)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "using GetSessionToken") {
+		t.Fatalf("did not expect GetSessionToken for a single-role login behind an alias, logs:\n%s", logs)
+	}
+	if strings.Contains(logs, "capping AssumeRole duration") {
+		t.Fatalf("did not expect AssumeRole duration capping for a single-role login, logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "profile target: using AssumeRole (with MFA)") {
+		t.Fatalf("expected target to use a direct AssumeRole (with MFA), logs:\n%s", logs)
+	}
+}
+
+// Ensures a role chain with a non-role passthrough profile still consolidates MFA via GetSessionToken and caps the chained AssumeRole calls.
+func TestPassthroughRoleChainingCapsAssumeRoleDurationToOneHour(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[profile source]
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+
+[profile admin]
+source_profile=source
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+role_arn=arn:aws:iam::222222222222:role/admin
+role_session_name=user
+
+[profile passthrough]
+source_profile=admin
+region=us-east-1
+
+[profile target]
+source_profile=passthrough
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+role_arn=arn:aws:iam::333333333333:role/target
+role_session_name=user
+`))
+	defer os.Remove(f)
+
+	base := vault.ProfileConfig{
+		AssumeRoleDuration:             12 * time.Hour,
+		ChainedGetSessionTokenDuration: 12 * time.Hour,
+	}
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := vault.NewConfigLoader(base, configFile, "target")
+	config, err := configLoader.GetProfileConfig("target")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	config.MfaToken = "123456"
+	config.SourceProfile.MfaToken = "123456"
+	config.SourceProfile.SourceProfile.MfaToken = "123456"
+	config.SourceProfile.SourceProfile.SourceProfile.MfaToken = "123456"
+
+	ckr := newSeededKeyring(t, "source")
+
+	buf := captureLogs(t)
+
+	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	admin := config.SourceProfile.SourceProfile
+	if admin.AssumeRoleDuration != vault.RoleChainingMaximumDuration {
+		t.Fatalf("expected admin AssumeRole duration to be capped to %s, got %s", vault.RoleChainingMaximumDuration, admin.AssumeRoleDuration)
+	}
+	if config.AssumeRoleDuration != vault.RoleChainingMaximumDuration {
+		t.Fatalf("expected target AssumeRole duration to be capped to %s, got %s", vault.RoleChainingMaximumDuration, config.AssumeRoleDuration)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "profile source: using GetSessionToken") {
+		t.Fatalf("expected source to consolidate MFA via GetSessionToken, logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "profile admin: using AssumeRole (chained MFA)") {
+		t.Fatalf("expected admin to use chained AssumeRole, logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "profile target: using AssumeRole (chained MFA)") {
+		t.Fatalf("expected target to use chained AssumeRole, logs:\n%s", logs)
+	}
+}
+
 // newSeededKeyring returns a CredentialKeyring with a single set of stub
 // credentials stored under the given profile name. Pass an empty name to get
 // an empty keyring.


### PR DESCRIPTION
## What changed

GetSessionToken priming is now decided by the number of roles in the credential chain. A new helper `rolesInChain` follows `ChainedFromProfile` from the profile being primed to the final target and counts the role profiles, and priming follows what the chain produces:

1. Exactly one role: direct login. GetSessionToken is skipped and the role is assumed straight from the long-term credentials, so the full requested duration is available, up to the role's maximum session duration setting, which can be configured up to 12h ([AssumeRole API reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)).
2. Zero roles: GetSessionToken as before, the session token itself is the deliverable, valid up to the 36h hard limit for IAM users ([GetSessionToken API reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html)).
3. Two or more roles: genuine role chaining. GetSessionToken once, so MFA is entered a single time, and every chained AssumeRole is capped to the 1h hard limit AWS applies to role chaining ([AssumeRole API reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html), DurationSeconds).

The classification depends only on the chain itself, so profiles without roles that only carry attributes like `region=` while sourcing credentials from another profile do not affect it:

| Chain                               | Behavior                             |
| ----------------------------------- | ------------------------------------ |
| `creds`                             | GetSessionToken, up to 36h           |
| `creds > role`                      | direct, full duration, up to 12h     |
| `creds > alias > role`              | direct, full duration, up to 12h     |
| `creds > role > role`               | GetSessionToken, 1h caps, single MFA |
| `creds > role > passthrough > role` | GetSessionToken, 1h caps, single MFA |

## Why

Previously a profile holding long-term credentials was primed whenever it fed a role profile, so a single role login through a source profile was routed through GetSessionToken. AssumeRole signed with a session token is capped to 1h by AWS, which means the requested `-d` was silently lost (#290). The only way to honor durations above 1h on a single role login is to assume the role directly from the long-term credentials.

Fixes #290, regression from #333.

## Unit Tests

New:

1. TestSourceProfileRoleLoginDoesNotCapAssumeRoleDuration: `creds > role` keeps the requested 12h.
2. TestAliasedSourceProfileRoleLoginDoesNotCapAssumeRoleDuration: `creds > alias > role` keeps the requested 12h.
3. TestPassthroughRoleChainingCapsAssumeRoleDurationToOneHour: `creds > role > passthrough > role` still consolidates MFA via GetSessionToken and caps each chained AssumeRole.

All existing direct login, role chaining and MFA tests pass unchanged.

Before:

```
--- FAIL: TestSourceProfileRoleLoginDoesNotCapAssumeRoleDuration (0.00s)
    vault_test.go:460: expected target AssumeRole duration to remain 12h0m0s, got 1h0m0s
--- FAIL: TestAliasedSourceProfileRoleLoginDoesNotCapAssumeRoleDuration (0.00s)
    vault_test.go:523: expected target AssumeRole duration to remain 12h0m0s, got 1h0m0s
```

After:

```
$ go test ./...
?       github.com/byteness/aws-vault/v7                 [no test files]
ok      github.com/byteness/aws-vault/v7/cli             0.020s
?       github.com/byteness/aws-vault/v7/internal/tty    [no test files]
ok      github.com/byteness/aws-vault/v7/iso8601         (cached)
?       github.com/byteness/aws-vault/v7/prompt          [no test files]
?       github.com/byteness/aws-vault/v7/server          [no test files]
ok      github.com/byteness/aws-vault/v7/vault           0.032s
```

## Smoke tests

The #290 scenario, a role profile sourcing long-term credentials from a non-role MFA profile:

```ini
[profile source]
region=us-east-1
mfa_serial=arn:aws:iam::111111111111:mfa/user

[profile target]
source_profile=source
region=us-east-1
mfa_serial=arn:aws:iam::111111111111:mfa/user
role_arn=arn:aws:iam::111111111111:role/target
```

Before, requesting 12h:

```
$ aws-vault exec target --debug -d 12h
profile target: sourcing credentials from profile source
profile source: using stored credentials
profile source: using GetSessionToken (with MFA)
profile target: capping AssumeRole duration from 12h0m0s to AWS maximum 1h0m0s for role chaining
profile target: using AssumeRole (chained MFA)
Generated credentials ... using GetSessionToken, expires in 11h59m59s
Generated credentials ... using AssumeRole, expires in 59m59s
```

After:

```
$ aws-vault exec target --debug -d 12h
profile target: sourcing credentials from profile source
profile source: using stored credentials
profile target: using AssumeRole (with MFA)
Generated credentials ... using AssumeRole, expires in 11h59m59s
```