### PR TITLE
fix(tests): Fix several bugs causing baseline tests to fail on Windows

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,8 @@ linters:
           list-mode: lax
           files:
             - $all
+          allow:
+            - $gostd
   enable:
     - bodyclose
     - contextcheck

--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -13,12 +13,12 @@ func ExampleAddCommand() {
 		log.Fatal(err)
 	}
 	defer os.Remove(f.Name())
+	f.Close()
 
 	fileDir, err := os.MkdirTemp("", "aws-vault-file-backend")
 	if err != nil {
 		log.Fatal(err)
 	}
-	f.Close()
 	defer os.RemoveAll(fileDir)
 
 	os.Setenv("AWS_CONFIG_FILE", f.Name())

--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -18,6 +18,7 @@ func ExampleAddCommand() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	f.Close()
 	defer os.RemoveAll(fileDir)
 
 	os.Setenv("AWS_CONFIG_FILE", f.Name())

--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -14,15 +14,24 @@ func ExampleAddCommand() {
 	}
 	defer os.Remove(f.Name())
 
+	fileDir, err := os.MkdirTemp("", "aws-vault-file-backend")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(fileDir)
+
 	os.Setenv("AWS_CONFIG_FILE", f.Name())
 	os.Setenv("AWS_ACCESS_KEY_ID", "llamas")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "rock")
 	os.Setenv("AWS_VAULT_BACKEND", "file")
+	os.Setenv("AWS_VAULT_FILE_DIR", fileDir)
 	os.Setenv("AWS_VAULT_FILE_PASSPHRASE", "password")
 
+	defer os.Unsetenv("AWS_CONFIG_FILE")
 	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
 	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 	defer os.Unsetenv("AWS_VAULT_BACKEND")
+	defer os.Unsetenv("AWS_VAULT_FILE_DIR")
 	defer os.Unsetenv("AWS_VAULT_FILE_PASSPHRASE")
 
 	app := kingpin.New(`aws-vault`, ``)

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -15,10 +15,6 @@ func ExampleExportCommand() {
 		log.Fatal(err)
 	}
 	defer os.Remove(f.Name())
-
-	if _, err = f.WriteString("[profile llamas]\nregion = us-east-1\n"); err != nil {
-		log.Fatal(err)
-	}
 	f.Close()
 
 	os.Setenv("AWS_CONFIG_FILE", f.Name())
@@ -38,5 +34,4 @@ func ExampleExportCommand() {
 	// [llamas]
 	// aws_access_key_id=ABC
 	// aws_secret_access_key=XYZ
-	// region=us-east-1
 }

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -38,4 +38,5 @@ func ExampleExportCommand() {
 	// [llamas]
 	// aws_access_key_id=ABC
 	// aws_secret_access_key=XYZ
+	// region=us-east-1
 }

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -1,12 +1,29 @@
 package cli
 
 import (
+	"log"
+	"os"
+
 	"github.com/alecthomas/kingpin/v2"
 
 	"github.com/byteness/keyring"
 )
 
 func ExampleExportCommand() {
+	f, err := os.CreateTemp("", "aws-config")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	if _, err = f.WriteString("[profile llamas]\nregion = us-east-1\n"); err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	os.Setenv("AWS_CONFIG_FILE", f.Name())
+	defer os.Unsetenv("AWS_CONFIG_FILE")
+
 	app := kingpin.New("aws-vault", "")
 	awsVault := ConfigureGlobals(app)
 	awsVault.keyringImpl = keyring.NewArrayKeyring([]keyring.Item{

--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -39,7 +39,7 @@ func msgFound(localised []string, toTest string) bool {
 func runAndWrapAdminErrors(name string, arg ...string) ([]byte, error) {
 	out, err := exec.Command(name, arg...).CombinedOutput()
 	if msgFound(runAsAdministratorLocalised, string(out)) {
-		const msg = "creation of network alias for server mode requires elevated permissions, run as administrator"
+		const msg = "Creation of network alias for server mode requires elevated permissions, run as administrator"
 		if err != nil {
 			err = fmt.Errorf("%s: %w", msg, err)
 		} else {


### PR DESCRIPTION
I encountered several issues out of the box after cloning `aws-vault` on Windows and running tests (see https://github.com/ByteNess/aws-vault/issues/367#issuecomment-4582968659). I think this might be because the CI here cannot test Windows, so there is a blind spot in your coverage. I fixed everything up so that it runs cleanly on Windows now and I can start developing on top of it^^

1. `server/ec2alias_windows.go`: Added `errors` import and replaced the bare `fmt.Errorf` (with args but no `%w`/`%v`) with proper `fmt.Errorf("%s: %w", msg, err)` / `errors.New(msg)`. Fixes `go vet`.
2. ~~`cli/exec_test.go`: Added `//go:build !windows` / `// +build !windows` at the top. The Unix `sh -c echo $AWS_ACCESS_KEY_ID` example panics on Windows via `os.Exit(0)`. This means currently `exec` won't be tested on Windows, the fix is a bit more complex and I'll make a separate PR for that.~~ _I excluded this workaround from the PR again, because it would cause issues when being merged with the next PR that properly fixes this issue!_
3. ~~`vault/vault_test.go`: Added `"runtime"` import and guarded the `0600` perm assertion with `runtime.GOOS != "windows"`. Windows doesn't honour POSIX permission bits!~~ (already done in #376, rebased)
4. `.golangci.yaml`: Added `allow: [$gostd]` under the `depguard` rule. golangci-lint v2 requires an allow and/or deny list; `lax` mode + `$gostd` keeps the "ban nothing" behaviour.
5. `cli/add_test.go`: Added `AWS_VAULT_FILE_DIR` pointing to a `os.MkdirTemp` directory. Without it the file backend resolved `~/.awsvault/keys/` to a relative path on Windows, creating `cli/~/.awsvault/keys/foo` in the repo. (I believe that `~` is used here at all is a separate bug in keyring but I'll need to investigate this later...)
6. `cli/export_test.go`: Made it hermetic: creates a temp config file with `region = us-east-1` for the `llamas` profile and sets `AWS_CONFIG_FILE`. Without this the test relied on the real `~/.aws/config` having a `us-east-1` default (which mine didn't have!).