### PR TITLE
fix(export): error message showed exec instead of export

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -93,7 +93,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 		}
 
 		err = ExportCommand(input, f, keyring)
-		app.FatalIfError(err, "exec")
+		app.FatalIfError(err, "export")
 		return nil
 	})
 }


### PR DESCRIPTION
Tiny bugfix: When `export` failed, the error would say `error: exec: ...` instead of `error: export: ...`.