### PR TITLE
fix: handle missing profiles

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -186,6 +186,10 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		return 0, err
 	}
 
+	if !profileResolvable(f, keyring, input.ProfileName) {
+		return 0, fmt.Errorf("profile '%s' not found in ~/.aws/config and no stored credentials exist for it", input.ProfileName)
+	}
+
 	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).GetProfileConfig(input.ProfileName)
 	if err != nil {
 		return 0, fmt.Errorf("Error loading config: %w", err)

--- a/cli/export.go
+++ b/cli/export.go
@@ -103,6 +103,10 @@ func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring keyrin
 		return fmt.Errorf("in an existing aws-vault subshell; 'exit' from the subshell or unset AWS_VAULT to force")
 	}
 
+	if !profileResolvable(f, keyring, input.ProfileName) {
+		return fmt.Errorf("profile '%s' not found in ~/.aws/config and no stored credentials exist for it", input.ProfileName)
+	}
+
 	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).GetProfileConfig(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)

--- a/cli/global.go
+++ b/cli/global.go
@@ -296,3 +296,15 @@ func pickAwsProfile2(profiles []string) (string, error) {
 
 	return ProfileName, err
 }
+
+// profileResolvable reports whether profileName can be used as a target profile:
+// either it has a section in the AWS config file, or long-term credentials are
+// stored under that name in the keyring. It is used to reject a mistyped or
+// non-existent profile before it silently inherits the [default] profile.
+func profileResolvable(f *vault.ConfigFile, k keyring.Keyring, profileName string) bool {
+	if _, ok := f.ProfileSection(profileName); ok {
+		return true
+	}
+	hasCred, _ := (&vault.CredentialKeyring{Keyring: k}).Has(profileName)
+	return hasCred
+}

--- a/cli/global_test.go
+++ b/cli/global_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -33,14 +34,14 @@ sso_role_name = ReadOnly
 
 func writeTempConfig(t *testing.T, b []byte) *vault.ConfigFile {
 	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "aws-config")
-	if err != nil {
+	// Write to a path rather than using os.CreateTemp: CreateTemp returns an
+	// open file handle, and on Windows t.TempDir() cleanup cannot remove a file
+	// that still has a live handle.
+	path := filepath.Join(t.TempDir(), "aws-config")
+	if err := os.WriteFile(path, b, 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(f.Name(), b, 0600); err != nil {
-		t.Fatal(err)
-	}
-	configFile, err := vault.LoadConfig(f.Name())
+	configFile, err := vault.LoadConfig(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/global_test.go
+++ b/cli/global_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
+)
+
+// issue377Config mirrors the configuration from issue #377: a canonical
+// [default] profile backed by SSO plus a second named SSO profile. The bug was
+// that targeting a non-existent profile silently inherited [default]'s SSO
+// account instead of erroring.
+var issue377Config = []byte(`[sso-session login-session]
+sso_start_url = https://example.awsapps.com/start#/
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[default]
+region = us-east-1
+sso_account_id = 222222222222
+sso_session = login-session
+sso_role_name = ReadOnly
+
+[profile demo]
+region = us-east-1
+sso_account_id = 333333333333
+sso_session = login-session
+sso_role_name = ReadOnly
+`)
+
+func writeTempConfig(t *testing.T, b []byte) *vault.ConfigFile {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "aws-config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f.Name(), b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	configFile, err := vault.LoadConfig(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return configFile
+}
+
+func TestProfileResolvable(t *testing.T) {
+	configFile := writeTempConfig(t, issue377Config)
+
+	// "creds-only" exists only in the keyring (added via `aws-vault add`), with
+	// no matching [profile] section. This is a supported case and must remain
+	// resolvable.
+	kr := keyring.NewArrayKeyring([]keyring.Item{
+		{Key: "creds-only", Data: []byte(`{"AccessKeyID":"ABC","SecretAccessKey":"XYZ"}`)},
+	})
+
+	tests := []struct {
+		name        string
+		profileName string
+		want        bool
+	}{
+		{"named profile with a config section", "demo", true},
+		{"the default profile", "default", true},
+		{"credentials-only profile present in keyring", "creds-only", true},
+		{"non-existent profile (issue #377)", "invalid-profile", false},
+		{"empty profile name", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := profileResolvable(configFile, kr, tc.profileName); got != tc.want {
+				t.Errorf("profileResolvable(%q) = %v, want %v", tc.profileName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecCommandRejectsMissingProfile is the regression test for issue #377:
+// exec must error on a non-existent profile rather than silently inheriting
+// [default]. The guard fires before any config load or execve, so calling
+// ExecCommand directly is safe on every platform.
+func TestExecCommandRejectsMissingProfile(t *testing.T) {
+	t.Setenv("AWS_VAULT", "") // ensure we are not treated as an existing subshell
+	configFile := writeTempConfig(t, issue377Config)
+	kr := keyring.NewArrayKeyring([]keyring.Item{})
+
+	_, err := ExecCommand(ExecCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr)
+	if err == nil {
+		t.Fatal("ExecCommand accepted a non-existent profile; expected an error (issue #377)")
+	}
+	if !strings.Contains(err.Error(), "invalid-profile") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestExportCommandRejectsMissingProfile covers the same guard on export, which
+// also closes the `exec --json` path (it delegates to ExportCommand).
+func TestExportCommandRejectsMissingProfile(t *testing.T) {
+	t.Setenv("AWS_VAULT", "")
+	configFile := writeTempConfig(t, issue377Config)
+	kr := keyring.NewArrayKeyring([]keyring.Item{})
+
+	err := ExportCommand(ExportCommandInput{ProfileName: "invalid-profile", Format: FormatTypeEnv, NoSession: true}, configFile, kr)
+	if err == nil {
+		t.Fatal("ExportCommand accepted a non-existent profile; expected an error (issue #377)")
+	}
+	if !strings.Contains(err.Error(), "invalid-profile") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestRotateCommandRejectsMissingProfile covers the same guard on rotate, so a
+// typo'd profile can't rotate the keys of the inherited [default] profile.
+func TestRotateCommandRejectsMissingProfile(t *testing.T) {
+	configFile := writeTempConfig(t, issue377Config)
+	kr := keyring.NewArrayKeyring([]keyring.Item{})
+
+	err := RotateCommand(RotateCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr)
+	if err == nil {
+		t.Fatal("RotateCommand accepted a non-existent profile; expected an error (issue #377)")
+	}
+	if !strings.Contains(err.Error(), "invalid-profile") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestMissingProfileInheritsDefault documents the underlying loader behaviour
+// that makes the guard necessary: GetProfileConfig does not error for a missing
+// profile and silently fills it from [default]. If this ever fails, the loader
+// behaviour changed and the CLI guard may no longer be the only thing between a
+// typo and the wrong account.
+func TestMissingProfileInheritsDefault(t *testing.T) {
+	configFile := writeTempConfig(t, issue377Config)
+
+	loader := &vault.ConfigLoader{File: configFile, ActiveProfile: "invalid-profile"}
+	config, err := loader.GetProfileConfig("invalid-profile")
+	if err != nil {
+		t.Fatalf("loader unexpectedly errored: %v", err)
+	}
+	if config.SSOAccountID != "222222222222" {
+		t.Fatalf("expected missing profile to inherit default SSO account %q, got %q",
+			"222222222222", config.SSOAccountID)
+	}
+}

--- a/cli/login.go
+++ b/cli/login.go
@@ -149,6 +149,13 @@ func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *v
 // LoginCommand creates a login URL for the AWS Management Console using the method described at
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
 func LoginCommand(ctx context.Context, input LoginCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+	// An empty ProfileName is valid for login: getCredsProvider falls back to
+	// environment credentials or an interactive profile picker. Only guard when
+	// the user explicitly named a profile.
+	if input.ProfileName != "" && !profileResolvable(f, keyring, input.ProfileName) {
+		return fmt.Errorf("profile '%s' not found in ~/.aws/config and no stored credentials exist for it", input.ProfileName)
+	}
+
 	config, err := vault.NewConfigLoader(input.Config, f, input.ProfileName).GetProfileConfig(input.ProfileName)
 	if err != nil {
 		return fmt.Errorf("Error loading config: %w", err)

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -63,6 +63,10 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 }
 
 func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+	if !profileResolvable(f, keyring, input.ProfileName) {
+		return fmt.Errorf("profile '%s' not found in ~/.aws/config and no stored credentials exist for it", input.ProfileName)
+	}
+
 	configLoader := vault.NewConfigLoader(input.Config, f, input.ProfileName)
 	config, err := configLoader.GetProfileConfig(input.ProfileName)
 	if err != nil {


### PR DESCRIPTION
Fixes: #377 

* Check for non-existing profiles which are also not in the cred store - error out instead of silently assuming default.
* Add tests