### PR TITLE
fix: error when exec profile not found instead of silently using default

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -151,6 +151,21 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 			}
 
 			input.ProfileName = ProfileName
+		} else {
+			// Validate the explicitly-provided profile name exists in the AWS config.
+			// Without this check a typo or a non-existent profile silently falls
+			// through to the AWS SDK which may resolve $AWS_DEFAULT_PROFILE or
+			// "default", leaking credentials from the wrong account.
+			found := false
+			for _, name := range f.ProfileNames() {
+				if name == input.ProfileName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("profile %q not found in AWS config — run 'aws-vault list' to see available profiles", input.ProfileName)
+			}
 		}
 
 		exitcode := 0


### PR DESCRIPTION
## Problem

Closes #377.

When `aws-vault exec invalid-profile -- <cmd>` is run and `invalid-profile` does not exist in `~/.aws/config`, the command succeeds silently and uses the `[default]` profile instead. This causes commands to run against the wrong AWS account with no warning.

## Root cause

`vault.ConfigLoader.populateFromConfigFile` has an explicit `// ignore missing profiles` path that logs a debug message and continues. Combined with the `exec` command accepting a profile name defaulting to `$AWS_PROFILE`, there was no validation that the named profile actually existed before proceeding.

## Fix

After the profile name is resolved (from CLI arg or interactive picker), check it against `f.ProfileNames()`. If the named profile is not present in the parsed AWS config, return an error before any credentials are fetched:

```
profile "invalid-profile" not found in AWS config — run 'aws-vault list' to see available profiles
```

## Before / After

**Before:**
```sh
$ aws-vault exec invalid-profile -- aws sts get-caller-identity
# silently uses [default] profile, returns account 2288...
```

**After:**
```sh
$ aws-vault exec invalid-profile -- aws sts get-caller-identity
Error: profile "invalid-profile" not found in AWS config — run 'aws-vault list' to see available profiles
```