### PR TITLE
feat: Migration of credentials between backends

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -428,6 +428,8 @@ aws-vault migrate-backend --from wincred --to winhello --delete-source
 
 Use `--dry-run` to list the credential profiles that would be migrated without reading secret data or writing anything. Use `--overwrite` to replace credentials that already exist in the destination backend.
 
+Note: Even with `--dry-run`, some source backends may prompt for confirmation in order to read the profile list itself.
+
 The command migrates long-lived aws-vault credentials only. It does not migrate cached STS sessions or SSO/OIDC tokens. If the destination backend requires interactive unlock, verification may prompt during migration.
 
 ### Rotating credentials

--- a/USAGE.md
+++ b/USAGE.md
@@ -20,6 +20,7 @@
     - [Using multiple profiles](#using-multiple-profiles)
     - [Listing profiles and credentials](#listing-profiles-and-credentials)
     - [Removing credentials](#removing-credentials)
+    - [Migrating credentials between backends](#migrating-credentials-between-backends)
     - [Rotating credentials](#rotating-credentials)
   - [Managing Sessions](#managing-sessions)
     - [Executing a command](#executing-a-command)
@@ -404,6 +405,30 @@ $ aws-vault remove work
 Delete credentials for profile "work"? (y|N) y
 Deleted credentials.
 ```
+
+### Migrating credentials between backends
+
+You can copy stored long-lived credentials from one backend to another:
+
+```shell
+aws-vault migrate-backend --from wincred --to winhello
+```
+
+To migrate one profile:
+
+```shell
+aws-vault migrate-backend --from wincred --to winhello --profile dev
+```
+
+By default, migration copies credentials and leaves the source backend unchanged. To delete source credentials after the destination has been written and verified:
+
+```shell
+aws-vault migrate-backend --from wincred --to winhello --delete-source
+```
+
+Use `--dry-run` to list the credential profiles that would be migrated without reading secret data or writing anything. Use `--overwrite` to replace credentials that already exist in the destination backend.
+
+The command migrates long-lived aws-vault credentials only. It does not migrate cached STS sessions or SSO/OIDC tokens. If the destination backend requires interactive unlock, verification may prompt during migration.
 
 ### Rotating credentials
 

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/byteness/aws-vault/v7/vault"
 	"github.com/byteness/keyring"
 )
 
@@ -53,7 +54,44 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 		return err
 	}
 
+	src, err := openSpecificBackend(cfg, input.FromBackend)
+	if err != nil {
+		return fmt.Errorf("open source backend %q: %w", input.FromBackend, err)
+	}
+	srcCreds := &vault.CredentialKeyring{Keyring: src}
+
+	profiles, err := migrationProfiles(srcCreds, input.ProfileName)
+	if err != nil {
+		return err
+	}
+
+	if input.DryRun {
+		for _, profile := range profiles {
+			fmt.Println(profile)
+		}
+		return nil
+	}
+
 	return fmt.Errorf("not implemented")
+}
+
+func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {
+	if profile != "" {
+		ok, err := src.Has(profile)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("profile %q not found in source backend", profile)
+		}
+		return []string{profile}, nil
+	}
+
+	profiles, err := src.Keys()
+	if err != nil {
+		return nil, err
+	}
+	return profiles, nil
 }
 
 func validateMigrateBackendInput(input MigrateBackendCommandInput) error {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
@@ -81,6 +82,14 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 	}
 	dstCreds := &vault.CredentialKeyring{Keyring: dst}
 
+	if _, err := migrateBackendProfiles(input, profiles, srcCreds, dstCreds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func migrateBackendProfiles(input MigrateBackendCommandInput, profiles []string, srcCreds *vault.CredentialKeyring, dstCreds *vault.CredentialKeyring) (migrateBackendSummary, error) {
 	summary := migrateBackendSummary{}
 	for _, profile := range profiles {
 		fmt.Printf("Migrating %s... ", profile)
@@ -88,14 +97,14 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 		if err != nil {
 			fmt.Printf("failed: %v\n", err)
 			fmt.Println("Migration stopped. Source credentials were not deleted for the failed profile.")
-			return err
+			return summary, err
 		}
 		message := result.Message
 		summary.Add(result)
 		if input.DeleteSource && result.Migrated {
 			if err := srcCreds.Remove(profile); err != nil {
 				fmt.Printf("failed: %v\n", err)
-				return fmt.Errorf("delete source profile %q: %w", profile, err)
+				return summary, fmt.Errorf("delete source profile %q: %w", profile, err)
 			}
 			message += ", deleted source"
 			summary.Deleted++
@@ -104,7 +113,7 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 	}
 	printMigrateBackendSummary(summary)
 
-	return nil
+	return summary, nil
 }
 
 func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []string) {
@@ -210,6 +219,7 @@ func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(profiles)
 	return profiles, nil
 }
 

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -81,23 +81,28 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 	}
 	dstCreds := &vault.CredentialKeyring{Keyring: dst}
 
+	summary := migrateBackendSummary{}
 	for _, profile := range profiles {
 		fmt.Printf("Migrating %s... ", profile)
 		result, err := migrateOneCredential(profile, srcCreds, dstCreds, input.Overwrite)
 		if err != nil {
 			fmt.Printf("failed: %v\n", err)
+			fmt.Println("Migration stopped. Source credentials were not deleted for the failed profile.")
 			return err
 		}
 		message := result.Message
+		summary.Add(result)
 		if input.DeleteSource && result.Migrated {
 			if err := srcCreds.Remove(profile); err != nil {
 				fmt.Printf("failed: %v\n", err)
 				return fmt.Errorf("delete source profile %q: %w", profile, err)
 			}
 			message += ", deleted source"
+			summary.Deleted++
 		}
 		fmt.Println(message)
 	}
+	printMigrateBackendSummary(summary)
 
 	return nil
 }
@@ -119,6 +124,42 @@ func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []stri
 type migrateCredentialResult struct {
 	Message  string
 	Migrated bool
+	Outcome  migrateCredentialOutcome
+}
+
+type migrateCredentialOutcome string
+
+const (
+	migrateCredentialCopied      migrateCredentialOutcome = "copied"
+	migrateCredentialOverwritten migrateCredentialOutcome = "overwritten"
+	migrateCredentialSkipped     migrateCredentialOutcome = "skipped"
+)
+
+type migrateBackendSummary struct {
+	Copied      int
+	Overwritten int
+	Skipped     int
+	Deleted     int
+}
+
+func (s *migrateBackendSummary) Add(result migrateCredentialResult) {
+	switch result.Outcome {
+	case migrateCredentialCopied:
+		s.Copied++
+	case migrateCredentialOverwritten:
+		s.Overwritten++
+	case migrateCredentialSkipped:
+		s.Skipped++
+	}
+}
+
+func printMigrateBackendSummary(summary migrateBackendSummary) {
+	fmt.Println()
+	fmt.Println("Migration summary:")
+	fmt.Printf("  copied: %d\n", summary.Copied)
+	fmt.Printf("  overwritten: %d\n", summary.Overwritten)
+	fmt.Printf("  skipped: %d\n", summary.Skipped)
+	fmt.Printf("  deleted from source: %d\n", summary.Deleted)
 }
 
 func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vault.CredentialKeyring, overwrite bool) (migrateCredentialResult, error) {
@@ -127,7 +168,7 @@ func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vau
 		return migrateCredentialResult{}, fmt.Errorf("check destination profile %q: %w", profile, err)
 	}
 	if exists && !overwrite {
-		return migrateCredentialResult{Message: "skipped, already exists in destination"}, nil
+		return migrateCredentialResult{Message: "skipped, already exists in destination", Outcome: migrateCredentialSkipped}, nil
 	}
 
 	creds, err := src.Get(profile)
@@ -148,9 +189,9 @@ func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vau
 	}
 
 	if exists {
-		return migrateCredentialResult{Message: "overwritten, verified", Migrated: true}, nil
+		return migrateCredentialResult{Message: "overwritten, verified", Migrated: true, Outcome: migrateCredentialOverwritten}, nil
 	}
-	return migrateCredentialResult{Message: "copied, verified", Migrated: true}, nil
+	return migrateCredentialResult{Message: "copied, verified", Migrated: true, Outcome: migrateCredentialCopied}, nil
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -124,11 +124,20 @@ func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vau
 	if err := dst.Set(profile, creds); err != nil {
 		return "", fmt.Errorf("write destination profile %q: %w", profile, err)
 	}
+	got, err := dst.Get(profile)
+	if err != nil {
+		return "", fmt.Errorf("verify destination profile %q: %w", profile, err)
+	}
+	if got.AccessKeyID != creds.AccessKeyID ||
+		got.SecretAccessKey != creds.SecretAccessKey ||
+		got.SessionToken != creds.SessionToken {
+		return "", fmt.Errorf("verify destination profile %q: credential mismatch", profile)
+	}
 
 	if exists {
-		return "overwritten", nil
+		return "overwritten, verified", nil
 	}
-	return "copied", nil
+	return "copied, verified", nil
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -22,16 +22,20 @@ type MigrateBackendCommandInput struct {
 // ConfigureMigrateBackendCommand adds the migrate-backend subcommand to the CLI.
 func ConfigureMigrateBackendCommand(app *kingpin.Application, a *AwsVault) {
 	input := MigrateBackendCommandInput{}
+	backendsAvailable := make([]string, 0, len(keyring.AvailableBackends()))
+	for _, backend := range keyring.AvailableBackends() {
+		backendsAvailable = append(backendsAvailable, string(backend))
+	}
 
 	cmd := app.Command("migrate-backend", "Migrate stored credentials between keyring backends.")
 
 	cmd.Flag("from", "Source keyring backend.").
 		Required().
-		StringVar(&input.FromBackend)
+		EnumVar(&input.FromBackend, backendsAvailable...)
 
 	cmd.Flag("to", "Destination keyring backend.").
 		Required().
-		StringVar(&input.ToBackend)
+		EnumVar(&input.ToBackend, backendsAvailable...)
 
 	cmd.Flag("profile", "Migrate only this profile.").
 		StringVar(&input.ProfileName)
@@ -194,9 +198,7 @@ func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vau
 	if err != nil {
 		return migrateCredentialResult{}, fmt.Errorf("verify destination profile %q: %w", profile, err)
 	}
-	if got.AccessKeyID != creds.AccessKeyID ||
-		got.SecretAccessKey != creds.SecretAccessKey ||
-		got.SessionToken != creds.SessionToken {
+	if got != creds {
 		return migrateCredentialResult{}, fmt.Errorf("verify destination profile %q: credential mismatch", profile)
 	}
 
@@ -207,45 +209,29 @@ func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vau
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {
-	if profile != "" {
-		ok, err := src.Has(profile)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, fmt.Errorf("profile %q not found in source backend", profile)
-		}
-		return []string{profile}, nil
-	}
-
 	profiles, err := src.Keys()
 	if err != nil {
 		return nil, err
 	}
+
+	if profile != "" {
+		for _, candidate := range profiles {
+			if candidate == profile {
+				return []string{profile}, nil
+			}
+		}
+		return nil, fmt.Errorf("profile %q not found in source backend", profile)
+	}
+
 	sort.Strings(profiles)
 	return profiles, nil
 }
 
 func validateMigrateBackendInput(input MigrateBackendCommandInput) error {
-	if !backendAvailable(input.FromBackend) {
-		return fmt.Errorf("source backend %q is not available", input.FromBackend)
-	}
-	if !backendAvailable(input.ToBackend) {
-		return fmt.Errorf("destination backend %q is not available", input.ToBackend)
-	}
 	if input.FromBackend == input.ToBackend {
 		return fmt.Errorf("source and destination backends must differ")
 	}
 	return nil
-}
-
-func backendAvailable(name string) bool {
-	for _, backend := range keyring.AvailableBackends() {
-		if string(backend) == name {
-			return true
-		}
-	}
-	return false
 }
 
 func openSpecificBackend(cfg keyring.Config, backendName string) (keyring.Keyring, error) {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -70,7 +70,28 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 		return nil
 	}
 
-	return fmt.Errorf("not implemented")
+	if len(profiles) == 0 {
+		fmt.Printf("No credentials found in source backend %s.\n", input.FromBackend)
+		return nil
+	}
+
+	dst, err := openSpecificBackend(cfg, input.ToBackend)
+	if err != nil {
+		return fmt.Errorf("open destination backend %q: %w", input.ToBackend, err)
+	}
+	dstCreds := &vault.CredentialKeyring{Keyring: dst}
+
+	for _, profile := range profiles {
+		fmt.Printf("Migrating %s... ", profile)
+		result, err := migrateOneCredential(profile, srcCreds, dstCreds, input.Overwrite)
+		if err != nil {
+			fmt.Printf("failed: %v\n", err)
+			return err
+		}
+		fmt.Println(result)
+	}
+
+	return nil
 }
 
 func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []string) {
@@ -85,6 +106,29 @@ func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []stri
 	}
 	fmt.Println()
 	fmt.Println("No changes made.")
+}
+
+func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vault.CredentialKeyring, overwrite bool) (string, error) {
+	exists, err := dst.Has(profile)
+	if err != nil {
+		return "", fmt.Errorf("check destination profile %q: %w", profile, err)
+	}
+	if exists && !overwrite {
+		return "skipped, already exists in destination", nil
+	}
+
+	creds, err := src.Get(profile)
+	if err != nil {
+		return "", fmt.Errorf("read source profile %q: %w", profile, err)
+	}
+	if err := dst.Set(profile, creds); err != nil {
+		return "", fmt.Errorf("write destination profile %q: %w", profile, err)
+	}
+
+	if exists {
+		return "overwritten", nil
+	}
+	return "copied", nil
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/byteness/keyring"
 )
 
+// MigrateBackendCommandInput contains the selected source, destination, and safety options.
 type MigrateBackendCommandInput struct {
 	FromBackend  string
 	ToBackend    string
@@ -18,6 +19,7 @@ type MigrateBackendCommandInput struct {
 	DeleteSource bool
 }
 
+// ConfigureMigrateBackendCommand adds the migrate-backend subcommand to the CLI.
 func ConfigureMigrateBackendCommand(app *kingpin.Application, a *AwsVault) {
 	input := MigrateBackendCommandInput{}
 
@@ -50,6 +52,7 @@ func ConfigureMigrateBackendCommand(app *kingpin.Application, a *AwsVault) {
 	})
 }
 
+// MigrateBackendCommand migrates long-lived credentials between keyring backends.
 func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config) error {
 	if err := validateMigrateBackendInput(input); err != nil {
 		return err

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -49,5 +49,36 @@ func ConfigureMigrateBackendCommand(app *kingpin.Application, a *AwsVault) {
 }
 
 func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config) error {
+	if err := validateMigrateBackendInput(input); err != nil {
+		return err
+	}
+
 	return fmt.Errorf("not implemented")
+}
+
+func validateMigrateBackendInput(input MigrateBackendCommandInput) error {
+	if !backendAvailable(input.FromBackend) {
+		return fmt.Errorf("source backend %q is not available", input.FromBackend)
+	}
+	if !backendAvailable(input.ToBackend) {
+		return fmt.Errorf("destination backend %q is not available", input.ToBackend)
+	}
+	if input.FromBackend == input.ToBackend {
+		return fmt.Errorf("source and destination backends must differ")
+	}
+	return nil
+}
+
+func backendAvailable(name string) bool {
+	for _, backend := range keyring.AvailableBackends() {
+		if string(backend) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func openSpecificBackend(cfg keyring.Config, backendName string) (keyring.Keyring, error) {
+	cfg.AllowedBackends = []keyring.BackendType{keyring.BackendType(backendName)}
+	return keyring.Open(cfg)
 }

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -88,7 +88,15 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 			fmt.Printf("failed: %v\n", err)
 			return err
 		}
-		fmt.Println(result)
+		message := result.Message
+		if input.DeleteSource && result.Migrated {
+			if err := srcCreds.Remove(profile); err != nil {
+				fmt.Printf("failed: %v\n", err)
+				return fmt.Errorf("delete source profile %q: %w", profile, err)
+			}
+			message += ", deleted source"
+		}
+		fmt.Println(message)
 	}
 
 	return nil
@@ -108,36 +116,41 @@ func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []stri
 	fmt.Println("No changes made.")
 }
 
-func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vault.CredentialKeyring, overwrite bool) (string, error) {
+type migrateCredentialResult struct {
+	Message  string
+	Migrated bool
+}
+
+func migrateOneCredential(profile string, src *vault.CredentialKeyring, dst *vault.CredentialKeyring, overwrite bool) (migrateCredentialResult, error) {
 	exists, err := dst.Has(profile)
 	if err != nil {
-		return "", fmt.Errorf("check destination profile %q: %w", profile, err)
+		return migrateCredentialResult{}, fmt.Errorf("check destination profile %q: %w", profile, err)
 	}
 	if exists && !overwrite {
-		return "skipped, already exists in destination", nil
+		return migrateCredentialResult{Message: "skipped, already exists in destination"}, nil
 	}
 
 	creds, err := src.Get(profile)
 	if err != nil {
-		return "", fmt.Errorf("read source profile %q: %w", profile, err)
+		return migrateCredentialResult{}, fmt.Errorf("read source profile %q: %w", profile, err)
 	}
 	if err := dst.Set(profile, creds); err != nil {
-		return "", fmt.Errorf("write destination profile %q: %w", profile, err)
+		return migrateCredentialResult{}, fmt.Errorf("write destination profile %q: %w", profile, err)
 	}
 	got, err := dst.Get(profile)
 	if err != nil {
-		return "", fmt.Errorf("verify destination profile %q: %w", profile, err)
+		return migrateCredentialResult{}, fmt.Errorf("verify destination profile %q: %w", profile, err)
 	}
 	if got.AccessKeyID != creds.AccessKeyID ||
 		got.SecretAccessKey != creds.SecretAccessKey ||
 		got.SessionToken != creds.SessionToken {
-		return "", fmt.Errorf("verify destination profile %q: credential mismatch", profile)
+		return migrateCredentialResult{}, fmt.Errorf("verify destination profile %q: credential mismatch", profile)
 	}
 
 	if exists {
-		return "overwritten, verified", nil
+		return migrateCredentialResult{Message: "overwritten, verified", Migrated: true}, nil
 	}
-	return "copied, verified", nil
+	return migrateCredentialResult{Message: "copied, verified", Migrated: true}, nil
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/byteness/keyring"
+)
+
+type MigrateBackendCommandInput struct {
+	FromBackend  string
+	ToBackend    string
+	ProfileName  string
+	DryRun       bool
+	Overwrite    bool
+	DeleteSource bool
+}
+
+func ConfigureMigrateBackendCommand(app *kingpin.Application, a *AwsVault) {
+	input := MigrateBackendCommandInput{}
+
+	cmd := app.Command("migrate-backend", "Migrate stored credentials between keyring backends.")
+
+	cmd.Flag("from", "Source keyring backend.").
+		Required().
+		StringVar(&input.FromBackend)
+
+	cmd.Flag("to", "Destination keyring backend.").
+		Required().
+		StringVar(&input.ToBackend)
+
+	cmd.Flag("profile", "Migrate only this profile.").
+		StringVar(&input.ProfileName)
+
+	cmd.Flag("dry-run", "Show what would be migrated without writing anything.").
+		BoolVar(&input.DryRun)
+
+	cmd.Flag("overwrite", "Overwrite destination credentials if they already exist.").
+		BoolVar(&input.Overwrite)
+
+	cmd.Flag("delete-source", "Delete source credentials after successful destination verification.").
+		BoolVar(&input.DeleteSource)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		err := MigrateBackendCommand(input, a.KeyringConfig)
+		app.FatalIfError(err, "migrate-backend")
+		return nil
+	})
+}
+
+func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config) error {
+	return fmt.Errorf("not implemented")
+}

--- a/cli/migrate_backend.go
+++ b/cli/migrate_backend.go
@@ -66,13 +66,25 @@ func MigrateBackendCommand(input MigrateBackendCommandInput, cfg keyring.Config)
 	}
 
 	if input.DryRun {
-		for _, profile := range profiles {
-			fmt.Println(profile)
-		}
+		printMigrateBackendDryRun(input, profiles)
 		return nil
 	}
 
 	return fmt.Errorf("not implemented")
+}
+
+func printMigrateBackendDryRun(input MigrateBackendCommandInput, profiles []string) {
+	if len(profiles) == 0 {
+		fmt.Printf("No credentials found in source backend %s.\n", input.FromBackend)
+		return
+	}
+
+	fmt.Printf("Would migrate %d credential profile(s) from %s to %s:\n", len(profiles), input.FromBackend, input.ToBackend)
+	for _, profile := range profiles {
+		fmt.Printf("  %s\n", profile)
+	}
+	fmt.Println()
+	fmt.Println("No changes made.")
 }
 
 func migrationProfiles(src *vault.CredentialKeyring, profile string) ([]string, error) {

--- a/cli/migrate_backend_test.go
+++ b/cli/migrate_backend_test.go
@@ -69,9 +69,9 @@ func TestMigrationProfilesExplicitMissingProfile(t *testing.T) {
 
 func TestMigrationProfilesExplicitlyRejectsSessionsAndOIDCTokens(t *testing.T) {
 	for _, key := range []string{
-		"oidc:https://example.com/start",
-		"session,ZGV2,,9999999999",
-		"dev session (61633665646639303539)",
+		"oidc:https://example.com/start",     // OIDC token key.
+		"session,ZGV2,,9999999999",           // Current session key for profile "dev".
+		"dev session (61633665646639303539)", // Legacy session key.
 	} {
 		t.Run(key, func(t *testing.T) {
 			src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring([]keyring.Item{{Key: key}})}

--- a/cli/migrate_backend_test.go
+++ b/cli/migrate_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/byteness/aws-vault/v7/vault"
 	"github.com/byteness/keyring"
@@ -22,13 +23,19 @@ func TestValidateMigrateBackendInput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected same backend validation error")
 	}
+}
 
-	err = validateMigrateBackendInput(MigrateBackendCommandInput{
-		FromBackend: "does-not-exist",
-		ToBackend:   string(backends[0]),
+func TestConfigureMigrateBackendCommandRejectsUnavailableBackend(t *testing.T) {
+	app := kingpin.New("aws-vault", "")
+	ConfigureMigrateBackendCommand(app, &AwsVault{})
+
+	_, err := app.Parse([]string{
+		"migrate-backend",
+		"--from", "does-not-exist",
+		"--to", string(keyring.AvailableBackends()[0]),
 	})
 	if err == nil {
-		t.Fatal("expected unavailable source backend validation error")
+		t.Fatal("expected unavailable backend parse error")
 	}
 }
 
@@ -57,6 +64,51 @@ func TestMigrationProfilesExplicitMissingProfile(t *testing.T) {
 	_, err := migrationProfiles(src, "missing")
 	if err == nil {
 		t.Fatal("expected missing profile error")
+	}
+}
+
+func TestMigrationProfilesExplicitlyRejectsSessionsAndOIDCTokens(t *testing.T) {
+	for _, key := range []string{
+		"oidc:https://example.com/start",
+		"session,ZGV2,,9999999999",
+		"dev session (61633665646639303539)",
+	} {
+		t.Run(key, func(t *testing.T) {
+			src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring([]keyring.Item{{Key: key}})}
+
+			_, err := migrationProfiles(src, key)
+			if err == nil {
+				t.Fatalf("expected explicit profile %q to be rejected", key)
+			}
+		})
+	}
+}
+
+func TestMigrateBackendProfilesCopiesCredential(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	dst := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	want := aws.Credentials{AccessKeyID: "SRC", SecretAccessKey: "source"}
+	mustSetDevCredential(t, src, want)
+
+	summary, err := migrateBackendProfiles(
+		MigrateBackendCommandInput{},
+		[]string{"dev"},
+		src,
+		dst,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Copied != 1 || summary.Overwritten != 0 || summary.Skipped != 0 || summary.Deleted != 0 {
+		t.Fatalf("summary = %#v, want one copied", summary)
+	}
+
+	got, err := dst.Get("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("destination credentials = %#v, want %#v", got, want)
 	}
 }
 

--- a/cli/migrate_backend_test.go
+++ b/cli/migrate_backend_test.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
+)
+
+func TestValidateMigrateBackendInput(t *testing.T) {
+	backends := keyring.AvailableBackends()
+	if len(backends) == 0 {
+		t.Fatal("expected at least one available keyring backend")
+	}
+
+	err := validateMigrateBackendInput(MigrateBackendCommandInput{
+		FromBackend: string(backends[0]),
+		ToBackend:   string(backends[0]),
+	})
+	if err == nil {
+		t.Fatal("expected same backend validation error")
+	}
+
+	err = validateMigrateBackendInput(MigrateBackendCommandInput{
+		FromBackend: "does-not-exist",
+		ToBackend:   string(backends[0]),
+	})
+	if err == nil {
+		t.Fatal("expected unavailable source backend validation error")
+	}
+}
+
+func TestMigrationProfilesFiltersSessionsAndOIDCTokens(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring([]keyring.Item{
+		{Key: "dev"},
+		{Key: "prod"},
+		{Key: "oidc:https://example.com/start"},
+		{Key: "session,ZGV2,,9999999999"},
+		{Key: "dev session (61633665646639303539)"},
+	})}
+
+	profiles, err := migrationProfiles(src, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"dev", "prod"}; !slices.Equal(profiles, want) {
+		t.Fatalf("profiles = %v, want %v", profiles, want)
+	}
+}
+
+func TestMigrationProfilesExplicitMissingProfile(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+
+	_, err := migrationProfiles(src, "missing")
+	if err == nil {
+		t.Fatal("expected missing profile error")
+	}
+}
+
+func TestMigrateOneCredentialSkipsExistingWithoutOverwrite(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	dst := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	mustSetDevCredential(t, src, aws.Credentials{AccessKeyID: "SRC", SecretAccessKey: "source"})
+	mustSetDevCredential(t, dst, aws.Credentials{AccessKeyID: "DST", SecretAccessKey: "destination"})
+
+	result, err := migrateOneCredential("dev", src, dst, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != migrateCredentialSkipped || result.Migrated {
+		t.Fatalf("result = %#v, want skipped without migration", result)
+	}
+
+	got, err := dst.Get("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessKeyID != "DST" {
+		t.Fatalf("destination AccessKeyID = %q, want original DST", got.AccessKeyID)
+	}
+}
+
+func TestMigrateBackendProfilesOverwritesAndDeletesSource(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	dst := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	want := aws.Credentials{AccessKeyID: "SRC", SecretAccessKey: "source"}
+	mustSetDevCredential(t, src, want)
+	mustSetDevCredential(t, dst, aws.Credentials{AccessKeyID: "DST", SecretAccessKey: "destination"})
+
+	summary, err := migrateBackendProfiles(
+		MigrateBackendCommandInput{Overwrite: true, DeleteSource: true},
+		[]string{"dev"},
+		src,
+		dst,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Overwritten != 1 || summary.Deleted != 1 || summary.Copied != 0 || summary.Skipped != 0 {
+		t.Fatalf("summary = %#v, want one overwritten and deleted", summary)
+	}
+
+	if ok, err := src.Has("dev"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("source profile still exists after verified delete-source migration")
+	}
+	got, err := dst.Get("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessKeyID != want.AccessKeyID || got.SecretAccessKey != want.SecretAccessKey {
+		t.Fatalf("destination credentials = %#v, want %#v", got, want)
+	}
+}
+
+func TestMigrateBackendProfilesVerificationFailureDoesNotDeleteSource(t *testing.T) {
+	src := &vault.CredentialKeyring{Keyring: keyring.NewArrayKeyring(nil)}
+	dst := &vault.CredentialKeyring{Keyring: corruptingGetKeyring{Keyring: keyring.NewArrayKeyring(nil)}}
+	mustSetDevCredential(t, src, aws.Credentials{AccessKeyID: "SRC", SecretAccessKey: "source"})
+
+	_, err := migrateBackendProfiles(
+		MigrateBackendCommandInput{DeleteSource: true},
+		[]string{"dev"},
+		src,
+		dst,
+	)
+	if err == nil {
+		t.Fatal("expected verification failure")
+	}
+
+	if ok, err := src.Has("dev"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("source profile was deleted after verification failure")
+	}
+}
+
+type corruptingGetKeyring struct {
+	keyring.Keyring
+}
+
+func (k corruptingGetKeyring) Get(key string) (keyring.Item, error) {
+	item, err := k.Keyring.Get(key)
+	if err != nil {
+		return item, err
+	}
+	item.Data = []byte(`{"AccessKeyID":"CORRUPTED","SecretAccessKey":"corrupted"}`)
+	return item, nil
+}
+
+func mustSetDevCredential(t *testing.T, ckr *vault.CredentialKeyring, creds aws.Credentials) {
+	t.Helper()
+	if err := ckr.Set("dev", creds); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	a := cli.ConfigureGlobals(app)
 	cli.ConfigureAddCommand(app, a)
 	cli.ConfigureRemoveCommand(app, a)
+	cli.ConfigureMigrateBackendCommand(app, a)
 	cli.ConfigureListCommand(app, a)
 	cli.ConfigureRotateCommand(app, a)
 	cli.ConfigureExecCommand(app, a)


### PR DESCRIPTION
As mentioned in https://github.com/ByteNess/aws-vault/issues/367, after creating the `winhello` backend, I wanted to be able to automatically migrate all my credentials from `wincred` to `winhello`.

This PR allows that, or rather, it adds a migration feature from any backend to any backend.

Summary:

Adds `aws-vault migrate-backend` for migrating long-lived stored credentials between keyring backends.

What the command does:

- migrates long-lived aws-vault credentials only
- skips cached STS sessions and SSO/OIDC tokens
- copies by default and leaves the source backend unchanged
- verifies each destination credential after writing
- optionally deletes source credentials only after successful verification
- supports dry-run, single-profile migration, and overwrite behavior

Examples:

```shell
aws-vault migrate-backend --from wincred --to winhello
aws-vault migrate-backend --from wincred --to winhello --profile dev
aws-vault migrate-backend --from wincred --to winhello --dry-run
aws-vault migrate-backend --from wincred --to winhello --overwrite
aws-vault migrate-backend --from wincred --to winhello --delete-source
```

Manual testing:

- `go test ./...` (Windows & Ubuntu)
- `go vet -all ./...` (Windows & Ubuntu)
- `go run . migrate-backend --from wincred --to winhello --dry-run` (Windows)
- manual test profile migration:
  - `file -> wincred` (Windows)
  - `wincred -> winhello` (Windows)
  - `wincred -> winhello --overwrite` (Windows)
  - first-use `winhello` key creation path (Windows)
  - `file -> pass` (Ubuntu)
  - verified source credentials are not deleted unless `--delete-source` is used (Windows & Ubuntu)

AI disclosure:
- I used ChatGPT to discuss design and implementation planning.
- I used GitHub Copilot in VSCode for code completions and for implementing certain functionality based on my technical instructions ("human-in-control" style). Agentic mode was used to create most unit tests, followed by manual review and adjustments.
- I reviewed and manually tested all the code on Windows 11 and Ubuntu (to ensure nothing breaks there) as described above.
