### PR TITLE
fix: restore shared MFA session for single-role profiles wit 1h cap

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -380,13 +380,39 @@ func rolesInChain(config *ProfileConfig) int {
 	return count
 }
 
+func maxAssumeRoleDurationInChain(config *ProfileConfig) time.Duration {
+	var max time.Duration
+	for c := config; c != nil; c = c.ChainedFromProfile {
+		if c.HasRole() && c.AssumeRoleDuration > max {
+			max = c.AssumeRoleDuration
+		}
+	}
+	return max
+}
+
 func (t *TempCredentialsCreator) primeWithGetSessionToken(config *ProfileConfig, sourcecredsProvider aws.CredentialsProvider) (aws.CredentialsProvider, bool, error) {
 	// IMPORTANT:
-	// GetSessionToken priming carries a single MFA authentication across the chain, but any AssumeRole made from the resulting session token is itself limited to 1h by AWS. So only prime when priming is actually needed:
-	//   - exactly one role in the chain: a direct role login. AssumeRole straight from the long-term credentials so the role's full max session duration is available. Do NOT prime.
-	//   - zero roles: the session token itself is the deliverable.
-	//   - two or more roles: genuine role chaining. Prime once so MFA is entered a single time. Each chained AssumeRole is then capped to 1h with capAssumeRoleDurationIfChained.
-	shouldPrime := rolesInChain(config) != 1
+	// GetSessionToken priming carries a single MFA authentication across the chain (the
+	// cached session on the source profile is shared by every role profile sourcing it),
+	// but any AssumeRole made from the resulting session token is itself limited to 1h by
+	// AWS. Prime when this profile is a session deliverable or a shared source for role
+	// profiles — unless skipping is actually worth it:
+	//   - no role, not a source for a role profile: the session token itself is the
+	//     deliverable. Prime.
+	//   - role profile holding its own long-term credentials: nothing to share a session
+	//     through. AssumeRole directly. Do NOT prime.
+	//   - source for a single role within the 1h cap (the default): priming loses
+	//     nothing, so prime to keep the MFA session shared across role profiles.
+	//   - source for a single role requesting more than the 1h chaining cap: AssumeRole
+	//     straight from the long-term credentials so the role's full session duration is
+	//     available, at the cost of an MFA prompt per role profile. Do NOT prime.
+	//   - two or more roles: genuine role chaining. Prime once so MFA is entered a single
+	//     time. Each chained AssumeRole is then capped to 1h with
+	//     capAssumeRoleDurationIfChained.
+	isSourceForRoleProfile := config.ChainedFromProfile != nil && config.ChainedFromProfile.HasRole()
+	singleRoleWantsLongDuration := rolesInChain(config) == 1 &&
+		maxAssumeRoleDurationInChain(config) > RoleChainingMaximumDuration
+	shouldPrime := (!config.HasRole() || isSourceForRoleProfile) && !singleRoleWantsLongDuration
 	if !shouldPrime || !isMasterCredentialsProvider(sourcecredsProvider) {
 		return sourcecredsProvider, true, nil
 	}

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -537,6 +537,56 @@ role_arn=arn:aws:iam::111111111111:role/target
 	}
 }
 
+// Ensures a single role within the 1h chaining cap is still primed with GetSessionToken on
+// the source profile, so the MFA session is shared across role profiles sourcing it (#392).
+func TestSingleRoleWithinCapPrimesGetSessionToken(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[profile source]
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+
+[profile target]
+source_profile=source
+region=us-east-1
+mfa_serial=arn:aws:iam::111111111111:mfa/user
+role_arn=arn:aws:iam::111111111111:role/target
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "target"}
+	config, err := configLoader.GetProfileConfig("target")
+	if err != nil {
+		t.Fatalf("Should have found a profile: %v", err)
+	}
+	config.MfaToken = "123456"
+	config.SourceProfile.MfaToken = "123456"
+
+	ckr := newSeededKeyring(t, "source")
+
+	buf := captureLogs(t)
+
+	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "profile source: using GetSessionToken") {
+		t.Fatalf("expected source to consolidate MFA via GetSessionToken, logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "profile target: using AssumeRole (chained MFA)") {
+		t.Fatalf("expected target to use chained AssumeRole, logs:\n%s", logs)
+	}
+	// Default duration is already within the chaining cap, so nothing to cap.
+	if strings.Contains(logs, "capping AssumeRole duration") {
+		t.Fatalf("did not expect AssumeRole duration capping at the default duration, logs:\n%s", logs)
+	}
+}
+
 // Ensures a role chain with a non-role passthrough profile still consolidates MFA via GetSessionToken and caps the chained AssumeRole calls.
 func TestPassthroughRoleChainingCapsAssumeRoleDurationToOneHour(t *testing.T) {
 	f := newConfigFile(t, []byte(`


### PR DESCRIPTION
Commit 99807b0 stopped `GetSessionToken` priming for all single-role chains so a role requesting `duration_seconds` > 3600 could keep its full duration. But it also stopped priming for roles at the default 1h duration, where priming costs nothing - each role profile sourcing the same MFA profile then needed its own MFA prompt, breaking parallel use of multiple profiles and leaving no cached session on the source profile.

Only skip priming when the single role actually requests more than the 1h role-chaining cap; otherwise prime the source profile as before so one MFA entry is shared by every role profile sourcing it. Role profiles holding their own long-term credentials are still never primed, and multi-role chains are still always primed.

Fixes #392