### PR TITLE
feat: Introduce faster opt-in alternative config parser

### DIFF
--- a/vault/config.go
+++ b/vault/config.go
@@ -9,8 +9,15 @@ import (
 	"strings"
 	"time"
 
-	ini "gopkg.in/ini.v1"
+	"github.com/byteness/aws-vault/v7/vault/configparser"
+	"github.com/byteness/aws-vault/v7/vault/configparser/custom"
+	"github.com/byteness/aws-vault/v7/vault/configparser/iniv1"
 )
+
+// ProfileSection and SSOSessionSection are type aliases so that existing
+// callers of vault.ProfileSection continue to work unchanged.
+type ProfileSection = configparser.ProfileSection
+type SSOSessionSection = configparser.SSOSessionSection
 
 const (
 	// DefaultSessionDuration is the default duration for GetSessionToken or AssumeRole sessions
@@ -22,17 +29,13 @@ const (
 	// RoleChainingMaximumDuration is the maximum duration for AssumeRole sessions when role chaining
 	RoleChainingMaximumDuration = time.Hour * 1
 
-	defaultSectionName = "default"
+	defaultSectionName = configparser.DefaultSectionName
 )
-
-func init() {
-	ini.PrettyFormat = false
-}
 
 // ConfigFile is an abstraction over what is in ~/.aws/config
 type ConfigFile struct {
-	Path    string
-	iniFile *ini.File
+	Path   string
+	parser configparser.Parser
 }
 
 // configPath returns either $AWS_CONFIG_FILE or ~/.aws/config
@@ -109,159 +112,52 @@ func LoadConfigFromEnv() (*ConfigFile, error) {
 	return LoadConfig(file)
 }
 
+// useCustomParser reports whether the custom bufio-based parser is enabled.
+// Set AWS_VAULT_USE_CUSTOM_INI_PARSER=true (or 1) to opt in.
+func useCustomParser() bool {
+	v := os.Getenv("AWS_VAULT_USE_CUSTOM_INI_PARSER")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
 func (c *ConfigFile) parseFile() error {
 	log.Printf("Parsing config file %s", c.Path)
-
-	f, err := ini.LoadSources(ini.LoadOptions{
-		AllowNestedValues:   true,
-		InsensitiveSections: false,
-		InsensitiveKeys:     true,
-		// Require a space before '#' to treat it as an inline comment.
-		// Without this, '#' in values like sso_start_url is stripped.
-		SpaceBeforeInlineComment: true,
-	}, c.Path)
-	if err != nil {
+	var p configparser.Parser
+	if useCustomParser() {
+		p = custom.New()
+	} else {
+		p = iniv1.New()
+	}
+	if err := p.Load(c.Path); err != nil {
 		return fmt.Errorf("Error parsing config file %s: %w", c.Path, err)
 	}
-	c.iniFile = f
+	c.parser = p
 	return nil
-}
-
-// ProfileSection is a profile section of the config file
-type ProfileSection struct {
-	Name                    string `ini:"-"`
-	MfaSerial               string `ini:"mfa_serial,omitempty"`
-	RoleARN                 string `ini:"role_arn,omitempty"`
-	ExternalID              string `ini:"external_id,omitempty"`
-	Region                  string `ini:"region,omitempty"`
-	RoleSessionName         string `ini:"role_session_name,omitempty"`
-	DurationSeconds         uint   `ini:"duration_seconds,omitempty"`
-	SourceProfile           string `ini:"source_profile,omitempty"`
-	IncludeProfile          string `ini:"include_profile,omitempty"`
-	SSOSession              string `ini:"sso_session,omitempty"`
-	SSOStartURL             string `ini:"sso_start_url,omitempty"`
-	SSORegion               string `ini:"sso_region,omitempty"`
-	SSOAccountID            string `ini:"sso_account_id,omitempty"`
-	SSORoleName             string `ini:"sso_role_name,omitempty"`
-	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
-	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
-	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
-	EndpointURL             string `ini:"endpoint_url,omitempty"`
-	SessionTags             string `ini:"session_tags,omitempty"`
-	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
-	SourceIdentity          string `ini:"source_identity,omitempty"`
-	CredentialProcess       string `ini:"credential_process,omitempty"`
-	MfaProcess              string `ini:"mfa_process,omitempty"`
-}
-
-// SSOSessionSection is a [sso-session] section of the config file
-type SSOSessionSection struct {
-	Name                  string `ini:"-"`
-	SSOStartURL           string `ini:"sso_start_url,omitempty"`
-	SSORegion             string `ini:"sso_region,omitempty"`
-	SSORegistrationScopes string `ini:"sso_registration_scopes,omitempty"`
-}
-
-func (s ProfileSection) IsEmpty() bool {
-	s.Name = ""
-	return s == ProfileSection{}
 }
 
 // ProfileSections returns all the profile sections in the config
 func (c *ConfigFile) ProfileSections() []ProfileSection {
-	result := []ProfileSection{}
-
-	if c.iniFile == nil {
-		return result
-	}
-	for _, section := range c.iniFile.SectionStrings() {
-		if section == defaultSectionName || strings.HasPrefix(section, "profile ") {
-			profile, _ := c.ProfileSection(strings.TrimPrefix(section, "profile "))
-
-			// ignore the default profile if it's empty
-			if section == defaultSectionName && profile.IsEmpty() {
-				continue
-			}
-
-			result = append(result, profile)
-		} else if strings.HasPrefix(section, "sso-session ") {
-			// Not a profile
-			continue
-		} else {
-			log.Printf("Unrecognised ini file section: %s", section)
-			continue
-		}
-	}
-
-	return result
+	return c.parser.ProfileSections()
 }
 
 // ProfileSection returns the profile section with the matching name. If there isn't any,
 // an empty profile with the provided name is returned, along with false.
 func (c *ConfigFile) ProfileSection(name string) (ProfileSection, bool) {
-	profile := ProfileSection{
-		Name: name,
-	}
-	if c.iniFile == nil {
-		return profile, false
-	}
-	// default profile name has a slightly different section format
-	sectionName := "profile " + name
-	if name == defaultSectionName {
-		sectionName = defaultSectionName
-	}
-	section, err := c.iniFile.GetSection(sectionName)
-	if err != nil {
-		return profile, false
-	}
-	if err = section.MapTo(&profile); err != nil {
-		panic(err)
-	}
-	return profile, true
+	return c.parser.ProfileSection(name)
 }
 
 // SSOSessionSection returns the [sso-session] section with the matching name. If there isn't any,
 // an empty sso-session with the provided name is returned, along with false.
 func (c *ConfigFile) SSOSessionSection(name string) (SSOSessionSection, bool) {
-	ssoSession := SSOSessionSection{
-		Name: name,
-	}
-	if c.iniFile == nil {
-		return ssoSession, false
-	}
-	sectionName := "sso-session " + name
-	section, err := c.iniFile.GetSection(sectionName)
-	if err != nil {
-		return ssoSession, false
-	}
-	if err = section.MapTo(&ssoSession); err != nil {
-		panic(err)
-	}
-	return ssoSession, true
+	return c.parser.SSOSessionSection(name)
 }
 
 func (c *ConfigFile) Save() error {
-	return c.iniFile.SaveTo(c.Path)
+	return c.parser.Save()
 }
 
-// Add the profile to the configuration file
+// Add the profile to the configuration file.
 func (c *ConfigFile) Add(profile ProfileSection) error {
-	if c.iniFile == nil {
-		return errors.New("No iniFile to add to")
-	}
-	// default profile name has a slightly different section format
-	sectionName := "profile " + profile.Name
-	if profile.Name == defaultSectionName {
-		sectionName = defaultSectionName
-	}
-	section, err := c.iniFile.NewSection(sectionName)
-	if err != nil {
-		return fmt.Errorf("Error creating section %q: %v", profile.Name, err)
-	}
-	if err = section.ReflectFrom(&profile); err != nil {
-		return fmt.Errorf("Error mapping profile to ini file: %v", err)
-	}
-	return c.Save()
+	return c.parser.Add(profile)
 }
 
 // ProfileNames returns a slice of profile names from the AWS config

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/byteness/aws-vault/v7/vault"
@@ -70,7 +71,7 @@ region=us-west-2
 output=json
 `)
 
-func newConfigFile(t *testing.T, b []byte) string {
+func newConfigFile(t testing.TB, b []byte) string {
 	t.Helper()
 	f, err := os.CreateTemp("", "aws-config")
 	if err != nil {
@@ -621,5 +622,777 @@ source_profile = interim
 
 	if len(baseConfig.TransitiveSessionTags) > 0 {
 		t.Fatalf("Expected transitive_session_tags to be empty, got %+v", baseConfig.TransitiveSessionTags)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parser correctness tests
+//
+// These document the exact behaviour of the ini.v1-based parser for AWS
+// config file inputs.  They serve as a regression baseline so that any future
+// parser swap can compare results directly.
+// ---------------------------------------------------------------------------
+
+// TestParserInlineHashComment verifies that a " #" sequence strips the rest of
+// a value as a comment, matching the SpaceBeforeInlineComment option.
+func TestParserInlineHashComment(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"region = us-east-1 # prod", "us-east-1"},
+		{"region = us-east-1  # extra space", "us-east-1"},
+		{"region = us-east-1 #no-space-after", "us-east-1"},
+		{"region = us-east-1 #", "us-east-1"},
+	}
+	for _, tc := range cases {
+		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("%q: load error: %v", tc.input, err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != tc.want {
+			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		}
+	}
+}
+
+// TestParserInlineSemicolonComment verifies that " ;" strips a trailing
+// semicolon comment, matching SpaceBeforeInlineComment behaviour.
+func TestParserInlineSemicolonComment(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"region = us-east-1 ; prod region", "us-east-1"},
+		{"region = us-east-1 ;", "us-east-1"},
+	}
+	for _, tc := range cases {
+		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("%q: load error: %v", tc.input, err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != tc.want {
+			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		}
+	}
+}
+
+// TestParserHashWithoutSpacePreserved verifies that "#" not preceded by a
+// space is kept as part of the value — important for URLs and ARNs.
+func TestParserHashWithoutSpacePreserved(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"endpoint_url = https://example.com/path#anchor", "https://example.com/path#anchor"},
+		{"endpoint_url = https://example.com#", "https://example.com#"},
+		{"role_session_name = foo#bar", "foo#bar"},
+	}
+	for _, tc := range cases {
+		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("%q: load error: %v", tc.input, err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		got := p.EndpointURL + p.RoleSessionName // one of the two will be populated
+		if got != tc.want {
+			t.Errorf("%q: want %q, got %q", tc.input, tc.want, got)
+		}
+	}
+}
+
+// TestParserSemicolonWithoutSpacePreserved verifies that ";" not preceded by a
+// space stays in the value.
+func TestParserSemicolonWithoutSpacePreserved(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+role_session_name = foo;bar
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.RoleSessionName != "foo;bar" {
+		t.Errorf("want %q, got %q", "foo;bar", p.RoleSessionName)
+	}
+}
+
+// TestParserSectionHeaderWithComment verifies that a comment after the closing
+// "]" of a section header does not prevent the section from being recognised.
+func TestParserSectionHeaderWithComment(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p] # production account
+region = us-east-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("expected profile 'p' to be parsed despite comment on section header")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q, got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserEmptyValue verifies that "key =" (empty value) is stored as an
+// empty string rather than omitted.
+func TestParserEmptyValue(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+role_arn =
+region = us-east-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.RoleARN != "" {
+		t.Errorf("want empty role_arn, got %q", p.RoleARN)
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q, got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserMixedCaseKeys verifies that key names are normalised to lower-case
+// regardless of how they appear in the file (InsensitiveKeys: true).
+func TestParserMixedCaseKeys(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+REGION = us-east-1
+Role_Arn = arn:aws:iam::123:role/Admin
+MFA_Serial = arn:aws:iam::123:mfa/user
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.Region != "us-east-1" {
+		t.Errorf("REGION: want %q, got %q", "us-east-1", p.Region)
+	}
+	if p.RoleARN != "arn:aws:iam::123:role/Admin" {
+		t.Errorf("Role_Arn: want arn, got %q", p.RoleARN)
+	}
+	if p.MfaSerial != "arn:aws:iam::123:mfa/user" {
+		t.Errorf("MFA_Serial: want arn, got %q", p.MfaSerial)
+	}
+}
+
+// TestParserWhitespaceTrimmedAroundValue verifies that leading and trailing
+// spaces around a value are stripped.
+func TestParserWhitespaceTrimmedAroundValue(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region   =   ap-southeast-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.Region != "ap-southeast-1" {
+		t.Errorf("want %q, got %q", "ap-southeast-1", p.Region)
+	}
+}
+
+// TestParserValueContainingEquals verifies that only the first "=" is the
+// key-value delimiter — subsequent "=" are part of the value.
+func TestParserValueContainingEquals(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+credential_process = aws-vault export --format=json --no-session
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	want := "aws-vault export --format=json --no-session"
+	if p.CredentialProcess != want {
+		t.Errorf("want %q, got %q", want, p.CredentialProcess)
+	}
+}
+
+// TestParserARNValue verifies that ARN strings (which contain ":" separators)
+// are preserved verbatim.  ini.v1 uses "=:" as key-value delimiters, so the
+// first "=" stops key scanning before any ":" in the value is reached.
+func TestParserARNValue(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+role_arn = arn:aws:iam::123456789012:role/MyRole
+mfa_serial = arn:aws:iam::123456789012:mfa/myuser
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	wantARN := "arn:aws:iam::123456789012:role/MyRole"
+	if p.RoleARN != wantARN {
+		t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
+	}
+	wantMFA := "arn:aws:iam::123456789012:mfa/myuser"
+	if p.MfaSerial != wantMFA {
+		t.Errorf("mfa_serial: want %q, got %q", wantMFA, p.MfaSerial)
+	}
+}
+
+// TestParserLargeNumberPreserved verifies that very large numeric strings are
+// kept as-is and not truncated or converted.
+func TestParserLargeNumberPreserved(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+role_session_name = 1234567890123456789012345678901234567890
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	want := "1234567890123456789012345678901234567890"
+	if p.RoleSessionName != want {
+		t.Errorf("want %q, got %q", want, p.RoleSessionName)
+	}
+}
+
+// TestParserNestedValuesSkippedForProfileFields verifies that indented
+// sub-property lines (AllowNestedValues) do not surface as profile fields —
+// aws-vault does not read s3, http_proxy, or other nested sections.
+func TestParserNestedValuesSkippedForProfileFields(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region = us-west-2
+s3 =
+  max_concurrent_requests = 10
+  max_queue_size = 1000
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.Region != "us-west-2" {
+		t.Errorf("want %q, got %q", "us-west-2", p.Region)
+	}
+}
+
+// TestParserPreSectionKeysIgnored verifies that key=value lines appearing
+// before any section header are silently discarded.
+func TestParserPreSectionKeysIgnored(t *testing.T) {
+	f := newConfigFile(t, []byte(`region = us-east-1
+[profile p]
+region = eu-west-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.Region != "eu-west-1" {
+		t.Errorf("want %q, got %q", "eu-west-1", p.Region)
+	}
+}
+
+// TestParserDuplicateSectionsMerged verifies that when the same section name
+// appears more than once its keys are merged, and ProfileSections() lists it
+// only once.
+func TestParserDuplicateSectionsMerged(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region = us-east-1
+
+[profile p]
+role_arn = arn:aws:iam::123:role/Admin
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
+	}
+	if p.RoleARN != "arn:aws:iam::123:role/Admin" {
+		t.Errorf("role_arn: want arn, got %q", p.RoleARN)
+	}
+	count := 0
+	for _, s := range cfg.ProfileSections() {
+		if s.Name == "p" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("want profile 'p' once in ProfileSections(), got %d", count)
+	}
+}
+
+// TestParserDuplicateKeyLastValueWins verifies that when a key appears more
+// than once in the same section, the last value is used.
+func TestParserDuplicateKeyLastValueWins(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region = us-east-1
+region = eu-west-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.Region != "eu-west-1" {
+		t.Errorf("want last value %q, got %q", "eu-west-1", p.Region)
+	}
+}
+
+// TestParserDeclarationOrderPreserved verifies that ProfileSections() returns
+// profiles in the order they appear in the file.
+func TestParserDeclarationOrderPreserved(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile alpha]
+region = us-east-1
+[profile beta]
+region = us-west-2
+[profile gamma]
+region = eu-west-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sections := cfg.ProfileSections()
+	names := make([]string, len(sections))
+	for i, s := range sections {
+		names[i] = s.Name
+	}
+	want := []string{"alpha", "beta", "gamma"}
+	if !reflect.DeepEqual(want, names) {
+		t.Errorf("want order %v, got %v", want, names)
+	}
+}
+
+// TestParserAllSectionTypes verifies that [default], [profile name] and
+// [sso-session name] are all correctly identified and accessible.
+func TestParserAllSectionTypes(t *testing.T) {
+	f := newConfigFile(t, []byte(`[default]
+region = us-east-1
+
+[profile myprofile]
+role_arn = arn:aws:iam::123:role/Admin
+sso_session = myorg
+
+[sso-session myorg]
+sso_start_url = https://myorg.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def, ok := cfg.ProfileSection("default")
+	if !ok || def.Region != "us-east-1" {
+		t.Errorf("default: want region us-east-1, got %q (ok=%v)", def.Region, ok)
+	}
+
+	prof, ok := cfg.ProfileSection("myprofile")
+	if !ok || prof.SSOSession != "myorg" {
+		t.Errorf("myprofile: want sso_session myorg, got %q (ok=%v)", prof.SSOSession, ok)
+	}
+
+	sso, ok := cfg.SSOSessionSection("myorg")
+	if !ok || sso.SSOStartURL != "https://myorg.awsapps.com/start" {
+		t.Errorf("sso-session: want start url, got %q (ok=%v)", sso.SSOStartURL, ok)
+	}
+	if sso.SSORegistrationScopes != "sso:account:access" {
+		t.Errorf("sso-session: want registration scopes, got %q", sso.SSORegistrationScopes)
+	}
+}
+
+// TestParserCommentOnlyLines verifies that lines starting with "#" or ";" are
+// treated as comments regardless of surrounding content.
+func TestParserCommentOnlyLines(t *testing.T) {
+	f := newConfigFile(t, []byte(`# full-line hash comment
+[profile p]
+; full-line semicolon comment
+region = us-east-1
+# trailing comment
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q, got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserQuotedValueStripped verifies ini.v1's default behaviour of
+// stripping matching surrounding double-quotes from a value.
+// Note: the AWS SDK parser does NOT strip quotes — this is an ini.v1-specific
+// behaviour that a replacement parser must handle explicitly or document.
+func TestParserQuotedValueStripped(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region = "us-east-1"
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	// ini.v1 strips surrounding double-quotes by default.
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q (quotes stripped), got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserTabBeforeCommentNotStripped documents that ini.v1 with
+// SpaceBeforeInlineComment=true requires a literal space (" #" or " ;") to
+// trigger comment stripping.  A tab before "#" or ";" is NOT a space, so the
+// tab and everything after it remains in the value.
+// The AWS SDK treats any whitespace (space OR tab) before a comment character
+// as a valid separator — this is an important divergence for hand-edited files.
+func TestParserTabBeforeCommentNotStripped(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"region = us-east-1\t# comment", "us-east-1\t# comment"},
+		{"region = us-east-1\t\t# comment", "us-east-1\t\t# comment"},
+		{"region = us-east-1\t; comment", "us-east-1\t; comment"},
+	}
+	for _, tc := range cases {
+		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("%q: load error: %v", tc.input, err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != tc.want {
+			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		}
+	}
+}
+
+// TestParserSpacesInsideSectionBracketsNotTrimmed documents that ini.v1 does
+// NOT trim whitespace inside the "[" "]" delimiters of a section header.
+// "[ profile foo ]" is stored with section name " profile foo " (spaces
+// preserved), so ProfileSection("foo") — which looks up "profile foo" — returns
+// false.  The AWS SDK DOES trim this whitespace, making the lookup succeed.
+func TestParserSpacesInsideSectionBracketsNotTrimmed(t *testing.T) {
+	f := newConfigFile(t, []byte("[ profile foo ]\nregion = us-east-1\n"))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := cfg.ProfileSection("foo")
+	if ok {
+		t.Error("ini.v1 preserves spaces inside brackets, so lookup for 'foo' should fail")
+	}
+}
+
+// TestParserValueStartingWithHashPreserved documents the boundary condition
+// where a value begins with "#" or ";" after the "=" without a preceding
+// space.  ini.v1 with SpaceBeforeInlineComment=true searches for " #" / " ;",
+// so a hash or semicolon as the first character of the value is NOT treated as
+// a comment — it stays in the value.
+// Contrast with the AWS SDK, which returns "" for "i = # comment".
+func TestParserValueStartingWithHashPreserved(t *testing.T) {
+	cases := []struct {
+		key, input, want string
+	}{
+		{"region", "region = # a note", "# a note"},
+		{"region", "region = ; a note", "; a note"},
+	}
+	for _, tc := range cases {
+		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("%q: load error: %v", tc.input, err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != tc.want {
+			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		}
+	}
+}
+
+// TestParserColonKeyValueDelimiter documents that ini.v1 accepts ":" as a
+// key-value separator in addition to "=" (KeyValueDelimiters = "=:").
+// A line like "region: us-east-1" is parsed identically to "region = us-east-1".
+// Any replacement parser that only handles "=" would silently discard such
+// lines.  In practice AWS configs use "=" exclusively, but the contract should
+// be explicit.
+func TestParserColonKeyValueDelimiter(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region: us-east-1
+role_arn: arn:aws:iam::123456789012:role/MyRole
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
+	}
+	// role_arn: arn:aws:... — the first ":" splits key from value, leaving
+	// " arn:aws:iam::..." as the value (colons in ARNs are safe because they
+	// come AFTER the key delimiter).
+	wantARN := "arn:aws:iam::123456789012:role/MyRole"
+	if p.RoleARN != wantARN {
+		t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
+	}
+}
+
+// TestParserSingleQuotedValueStripped verifies that ini.v1 strips matching
+// surrounding single-quotes as well as double-quotes.
+// Note: the AWS SDK preserves quotes — this is an ini.v1-specific behaviour.
+func TestParserSingleQuotedValueStripped(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+region = 'us-east-1'
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := cfg.ProfileSection("p")
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q (single quotes stripped), got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserEmptyFile verifies that LoadConfig on a zero-byte file succeeds and
+// returns no profile sections.
+func TestParserEmptyFile(t *testing.T) {
+	f := newConfigFile(t, []byte{})
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatalf("unexpected error on empty file: %v", err)
+	}
+	if sections := cfg.ProfileSections(); len(sections) != 0 {
+		t.Errorf("want 0 sections, got %d: %v", len(sections), sections)
+	}
+}
+
+// TestParserFileWithoutTrailingNewline verifies that a config file whose last
+// line is not terminated by a newline is parsed correctly.
+func TestParserFileWithoutTrailingNewline(t *testing.T) {
+	f := newConfigFile(t, []byte("[profile p]\nregion=us-east-1")) // no trailing \n
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q, got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserServicesSectionNotInProfileSections verifies that [services name]
+// sections (used by the AWS CLI for endpoint customisation) are not returned by
+// ProfileSections().
+func TestParserServicesSectionNotInProfileSections(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile myprofile]
+region = us-east-1
+
+[services my-endpoints]
+s3 =
+  endpoint_url = https://s3.example.com
+
+[profile another]
+region = us-west-2
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sections := cfg.ProfileSections()
+	for _, s := range sections {
+		if strings.Contains(s.Name, "services") {
+			t.Errorf("services section must not appear in ProfileSections(), got %q", s.Name)
+		}
+	}
+	if len(sections) != 2 {
+		t.Errorf("want 2 profile sections, got %d: %v", len(sections), sections)
+	}
+}
+
+// TestParserSectionHeaderWithSemicolonComment extends
+// TestParserSectionHeaderWithComment to verify that a semicolon comment after
+// the closing "]" is also handled correctly.
+func TestParserSectionHeaderWithSemicolonComment(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p] ; production account
+region = us-east-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("expected profile 'p' to be parsed despite semicolon comment on section header")
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("want %q, got %q", "us-east-1", p.Region)
+	}
+}
+
+// TestParserDurationSecondsEmpty verifies that an empty duration_seconds value
+// ("duration_seconds =") does not cause a parse error and results in the zero
+// uint value (treated as unset).
+func TestParserDurationSecondsEmpty(t *testing.T) {
+	f := newConfigFile(t, []byte(`[profile p]
+duration_seconds =
+region = us-east-1
+`))
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	p, ok := cfg.ProfileSection("p")
+	if !ok {
+		t.Fatal("profile not found")
+	}
+	if p.DurationSeconds != 0 {
+		t.Errorf("want DurationSeconds=0 for empty value, got %d", p.DurationSeconds)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func generateLargeConfig(b *testing.B, n int) string {
+	b.Helper()
+	f, err := os.CreateTemp("", "aws-config-large")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "[default]\nregion=us-east-1\n\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(f, "[profile sso-acct%d-role%d]\nsso_account_id=%012d\nsso_role_name=role%d\nsso_start_url=https://d-abc123.awsapps.com/start\nsso_region=us-east-1\nregion=us-east-1\n\n", i, i, i, i)
+		fmt.Fprintf(f, "[profile exec-sso-acct%d-role%d]\ncredential_process=aws-vault export --format=json sso-acct%d-role%d\n\n", i, i, i, i)
+	}
+	return f.Name()
+}
+
+func BenchmarkParseSmallConfig(b *testing.B) {
+	f := newConfigFile(b, exampleConfig)
+	defer os.Remove(f)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = cfg
+	}
+}
+
+func BenchmarkParseLargeSyntheticConfig(b *testing.B) {
+	path := generateLargeConfig(b, 87000)
+	defer os.Remove(path)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg, err := vault.LoadConfig(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = cfg
+	}
+}
+
+func BenchmarkParseRealConfig(b *testing.B) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		b.Skip("no home dir:", err)
+	}
+	path := home + "/.aws/config"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		b.Skip("no config file at", path)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg, err := vault.LoadConfig(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = cfg
+	}
+}
+
+func BenchmarkProfileSectionLookup(b *testing.B) {
+	f := newConfigFile(b, exampleConfig)
+	defer os.Remove(f)
+	cfg, err := vault.LoadConfig(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p, _ := cfg.ProfileSection("withMFA")
+		_ = p
+	}
+}
+
+func BenchmarkProfileSections(b *testing.B) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		b.Skip("no home dir:", err)
+	}
+	path := home + "/.aws/config"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		b.Skip("no config file at", path)
+	}
+	cfg, err := vault.LoadConfig(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sections := cfg.ProfileSections()
+		_ = sections
 	}
 }

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -77,229 +77,259 @@ func newConfigFile(t testing.TB, b []byte) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(f.Name(), b, 0600); err != nil {
+	name := f.Name()
+	f.Close()
+	if err := os.WriteFile(name, b, 0600); err != nil {
 		t.Fatal(err)
 	}
-	return f.Name()
+	return name
+}
+
+// testBothParsers runs fn twice: once with the default ini.v1 parser and once
+// with the custom bufio parser (AWS_VAULT_USE_CUSTOM_INI_PARSER=true). Both
+// sub-tests must pass, proving the two parsers produce identical results.
+func testBothParsers(t *testing.T, fn func(t *testing.T)) {
+	t.Helper()
+	t.Run("ini", fn)
+	t.Run("custom", func(t *testing.T) {
+		t.Setenv("AWS_VAULT_USE_CUSTOM_INI_PARSER", "true")
+		fn(t)
+	})
 }
 
 func TestProfileNameCaseSensitivity(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	def, ok := cfg.ProfileSection("withMFA")
-	if !ok {
-		t.Fatalf("Expected to match profile withMFA")
-	}
+		def, ok := cfg.ProfileSection("withMFA")
+		if !ok {
+			t.Fatalf("Expected to match profile withMFA")
+		}
 
-	expectedMfaSerial := "arn:aws:iam::1234513441:mfa/blah"
-	if def.MfaSerial != expectedMfaSerial {
-		t.Fatalf("Expected %s, got %s", expectedMfaSerial, def.MfaSerial)
-	}
+		expectedMfaSerial := "arn:aws:iam::1234513441:mfa/blah"
+		if def.MfaSerial != expectedMfaSerial {
+			t.Fatalf("Expected %s, got %s", expectedMfaSerial, def.MfaSerial)
+		}
+	})
 }
 
 func TestConfigParsingProfiles(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	var testCases = []struct {
-		expected vault.ProfileSection
-		ok       bool
-	}{
-		{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
-		{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
-		{vault.ProfileSection{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"}, true},
-		{vault.ProfileSection{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"}, true},
-		{vault.ProfileSection{Name: "nopenotthere"}, false},
-	}
+		var testCases = []struct {
+			expected vault.ProfileSection
+			ok       bool
+		}{
+			{vault.ProfileSection{Name: "user2", Region: "us-east-1"}, true},
+			{vault.ProfileSection{Name: "withsource", SourceProfile: "user2", Region: "us-east-1"}, true},
+			{vault.ProfileSection{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"}, true},
+			{vault.ProfileSection{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"}, true},
+			{vault.ProfileSection{Name: "nopenotthere"}, false},
+		}
 
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("profile_%s", tc.expected.Name), func(t *testing.T) {
-			actual, ok := cfg.ProfileSection(tc.expected.Name)
-			if ok != tc.ok {
-				t.Fatalf("Expected second param to be %v, got %v", tc.ok, ok)
-			}
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("ProfileSection() mismatch (-expected +actual):\n%s", diff)
-			}
-		})
-	}
+		for _, tc := range testCases {
+			t.Run(fmt.Sprintf("profile_%s", tc.expected.Name), func(t *testing.T) {
+				actual, ok := cfg.ProfileSection(tc.expected.Name)
+				if ok != tc.ok {
+					t.Fatalf("Expected second param to be %v, got %v", tc.ok, ok)
+				}
+				if diff := cmp.Diff(tc.expected, actual); diff != "" {
+					t.Errorf("ProfileSection() mismatch (-expected +actual):\n%s", diff)
+				}
+			})
+		}
+	})
 }
 
 func TestConfigParsingDefault(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	def, ok := cfg.ProfileSection("default")
-	if !ok {
-		t.Fatalf("Expected to find default profile")
-	}
+		def, ok := cfg.ProfileSection("default")
+		if !ok {
+			t.Fatalf("Expected to find default profile")
+		}
 
-	expected := vault.ProfileSection{
-		Name:   "default",
-		Region: "us-west-2",
-	}
+		expected := vault.ProfileSection{
+			Name:   "default",
+			Region: "us-west-2",
+		}
 
-	if !reflect.DeepEqual(def, expected) {
-		t.Fatalf("Expected %+v, got %+v", expected, def)
-	}
+		if !reflect.DeepEqual(def, expected) {
+			t.Fatalf("Expected %+v, got %+v", expected, def)
+		}
+	})
 }
 
 func TestProfilesFromConfig(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	expected := []vault.ProfileSection{
-		{Name: "default", Region: "us-west-2"},
-		{Name: "user2", Region: "us-east-1"},
-		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
-		{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
-		{Name: "testincludeprofile1", Region: "us-east-1"},
-		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
-		{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},
-	}
-	actual := cfg.ProfileSections()
+		expected := []vault.ProfileSection{
+			{Name: "default", Region: "us-west-2"},
+			{Name: "user2", Region: "us-east-1"},
+			{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
+			{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
+			{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
+			{Name: "testincludeprofile1", Region: "us-east-1"},
+			{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
+			{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},
+		}
+		actual := cfg.ProfileSections()
 
-	if diff := cmp.Diff(expected, actual); diff != "" {
-		t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
-	}
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
+		}
+	})
 }
 
 func TestAddProfileToExistingConfig(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	err = cfg.Add(vault.ProfileSection{
-		Name:          "llamas",
-		MfaSerial:     "testserial",
-		Region:        "us-east-1",
-		SourceProfile: "default",
+		err = cfg.Add(vault.ProfileSection{
+			Name:          "llamas",
+			MfaSerial:     "testserial",
+			Region:        "us-east-1",
+			SourceProfile: "default",
+		})
+		if err != nil {
+			t.Fatalf("Error adding profile: %#v", err)
+		}
+
+		expected := []vault.ProfileSection{
+			{Name: "default", Region: "us-west-2"},
+			{Name: "user2", Region: "us-east-1"},
+			{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
+			{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
+			{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
+			{Name: "testincludeprofile1", Region: "us-east-1"},
+			{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
+			{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},
+			{Name: "llamas", MfaSerial: "testserial", Region: "us-east-1", SourceProfile: "default"},
+		}
+		actual := cfg.ProfileSections()
+
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
+		}
 	})
-	if err != nil {
-		t.Fatalf("Error adding profile: %#v", err)
-	}
-
-	expected := []vault.ProfileSection{
-		{Name: "default", Region: "us-west-2"},
-		{Name: "user2", Region: "us-east-1"},
-		{Name: "withsource", Region: "us-east-1", SourceProfile: "user2"},
-		{Name: "withMFA", MfaSerial: "arn:aws:iam::1234513441:mfa/blah", RoleARN: "arn:aws:iam::4451234513441615400570:role/aws_admin", Region: "us-east-1", DurationSeconds: 1200, SourceProfile: "user2", STSRegionalEndpoints: "legacy"},
-		{Name: "withendpointurl", Region: "us-east-1", EndpointURL: "https://localhost:1234"},
-		{Name: "testincludeprofile1", Region: "us-east-1"},
-		{Name: "testincludeprofile2", IncludeProfile: "testincludeprofile1"},
-		{Name: "with-sso-session", SSOSession: "moon-sso", Region: "moon-1", SSOAccountID: "123456"},
-		{Name: "llamas", MfaSerial: "testserial", Region: "us-east-1", SourceProfile: "default"},
-	}
-	actual := cfg.ProfileSections()
-
-	if diff := cmp.Diff(expected, actual); diff != "" {
-		t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
-	}
 }
 
 func TestAddProfileToExistingNestedConfig(t *testing.T) {
-	f := newConfigFile(t, nestedConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, nestedConfig)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	err = cfg.Add(vault.ProfileSection{
-		Name:      "llamas",
-		MfaSerial: "testserial",
-		Region:    "us-east-1",
+		err = cfg.Add(vault.ProfileSection{
+			Name:      "llamas",
+			MfaSerial: "testserial",
+			Region:    "us-east-1",
+		})
+		if err != nil {
+			t.Fatalf("Error adding profile: %#v", err)
+		}
+
+		expected := append(nestedConfig, []byte(
+			"\n[profile llamas]\nmfa_serial=testserial\nregion=us-east-1\n",
+		)...)
+
+		b, _ := os.ReadFile(f)
+
+		if !bytes.Equal(expected, b) {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+		}
 	})
-	if err != nil {
-		t.Fatalf("Error adding profile: %#v", err)
-	}
-
-	expected := append(nestedConfig, []byte(
-		"\n[profile llamas]\nmfa_serial=testserial\nregion=us-east-1\n",
-	)...)
-
-	b, _ := os.ReadFile(f)
-
-	if !bytes.Equal(expected, b) {
-		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
-	}
 }
 
 func TestIncludeProfile(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	configLoader := &vault.ConfigLoader{File: configFile}
-	config, err := configLoader.GetProfileConfig("testincludeprofile2")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
+		configLoader := &vault.ConfigLoader{File: configFile}
+		config, err := configLoader.GetProfileConfig("testincludeprofile2")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
 
-	if config.Region != "us-east-1" {
-		t.Fatalf("Expected region %q, got %q", "us-east-1", config.Region)
-	}
+		if config.Region != "us-east-1" {
+			t.Fatalf("Expected region %q, got %q", "us-east-1", config.Region)
+		}
+	})
 }
 
 func TestIncludeSsoSession(t *testing.T) {
-	f := newConfigFile(t, exampleConfig)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, exampleConfig)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	configLoader := &vault.ConfigLoader{File: configFile}
-	config, err := configLoader.GetProfileConfig("with-sso-session")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
+		configLoader := &vault.ConfigLoader{File: configFile}
+		config, err := configLoader.GetProfileConfig("with-sso-session")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
 
-	if config.Region != "moon-1" { // Test not the same as SSO region
-		t.Fatalf("Expected region %q, got %q", "moon-1", config.Region)
-	}
+		if config.Region != "moon-1" { // Test not the same as SSO region
+			t.Fatalf("Expected region %q, got %q", "moon-1", config.Region)
+		}
 
-	ssoStartURL := "https://d-123456789.example.com/start"
-	if config.SSOStartURL != ssoStartURL {
-		t.Fatalf("Expected sso_start_url %q, got %q", ssoStartURL, config.Region)
-	}
+		ssoStartURL := "https://d-123456789.example.com/start"
+		if config.SSOStartURL != ssoStartURL {
+			t.Fatalf("Expected sso_start_url %q, got %q", ssoStartURL, config.Region)
+		}
 
-	if config.SSORegion != "moon-2" { // Test not the same as profile region
-		t.Fatalf("Expected sso_region %q, got %q", "moon-2", config.Region)
-	}
-	// Not checking sso_registration_scopes as it seems to be unused by aws-cli.
+		if config.SSORegion != "moon-2" { // Test not the same as profile region
+			t.Fatalf("Expected sso_region %q, got %q", "moon-2", config.Region)
+		}
+		// Not checking sso_registration_scopes as it seems to be unused by aws-cli.
+	})
 }
 
 func TestProfileIsEmpty(t *testing.T) {
@@ -310,119 +340,127 @@ func TestProfileIsEmpty(t *testing.T) {
 }
 
 func TestIniWithHeaderSavesWithHeader(t *testing.T) {
-	f := newConfigFile(t, defaultsOnlyConfigWithHeader)
-	defer os.Remove(f)
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, defaultsOnlyConfigWithHeader)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	err = cfg.Save()
-	if err != nil {
-		t.Fatal(err)
-	}
+		err = cfg.Save()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	expected := defaultsOnlyConfigWithHeader
+		expected := defaultsOnlyConfigWithHeader
 
-	b, _ := os.ReadFile(f)
+		b, _ := os.ReadFile(f)
 
-	if !bytes.Equal(expected, b) {
-		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
-	}
+		if !bytes.Equal(expected, b) {
+			t.Fatalf("Expected:\n%q\nGot:\n%q", expected, b)
+		}
+	})
 }
 
 func TestIniWithDEFAULTHeader(t *testing.T) {
-	f := newConfigFile(t, []byte(`[DEFAULT]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[DEFAULT]
 region=us-east-1
 [default]
 region=us-west-2
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := []vault.ProfileSection{
-		{Name: "default", Region: "us-west-2"},
-	}
-	actual := cfg.ProfileSections()
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := []vault.ProfileSection{
+			{Name: "default", Region: "us-west-2"},
+		}
+		actual := cfg.ProfileSections()
 
-	if diff := cmp.Diff(expected, actual); diff != "" {
-		t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
-	}
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("ProfileSections() mismatch (-expected +actual):\n%s", diff)
+		}
+	})
 }
 
 func TestLoadedProfileDoesntReferToItself(t *testing.T) {
-	f := newConfigFile(t, []byte(`
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`
 [profile foo]
 source_profile=foo
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	def, ok := configFile.ProfileSection("foo")
-	if !ok {
-		t.Fatalf("Couldn't load profile foo")
-	}
+		def, ok := configFile.ProfileSection("foo")
+		if !ok {
+			t.Fatalf("Couldn't load profile foo")
+		}
 
-	expectedSourceProfile := "foo"
-	if def.SourceProfile != expectedSourceProfile {
-		t.Fatalf("Expected '%s', got '%s'", expectedSourceProfile, def.SourceProfile)
-	}
+		expectedSourceProfile := "foo"
+		if def.SourceProfile != expectedSourceProfile {
+			t.Fatalf("Expected '%s', got '%s'", expectedSourceProfile, def.SourceProfile)
+		}
 
-	configLoader := &vault.ConfigLoader{File: configFile}
-	config, err := configLoader.GetProfileConfig("foo")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
+		configLoader := &vault.ConfigLoader{File: configFile}
+		config, err := configLoader.GetProfileConfig("foo")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
 
-	expectedSourceProfileName := ""
-	if config.SourceProfileName != expectedSourceProfileName {
-		t.Fatalf("Expected '%s', got '%s'", expectedSourceProfileName, config.SourceProfileName)
-	}
+		expectedSourceProfileName := ""
+		if config.SourceProfileName != expectedSourceProfileName {
+			t.Fatalf("Expected '%s', got '%s'", expectedSourceProfileName, config.SourceProfileName)
+		}
+	})
 }
 
 func TestSourceProfileCanReferToParent(t *testing.T) {
-	f := newConfigFile(t, []byte(`
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`
 [profile root]
 
 [profile foo]
 include_profile=root
 source_profile=root
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	def, ok := configFile.ProfileSection("foo")
-	if !ok {
-		t.Fatalf("Couldn't load profile foo")
-	}
+		def, ok := configFile.ProfileSection("foo")
+		if !ok {
+			t.Fatalf("Couldn't load profile foo")
+		}
 
-	expectedSourceProfile := "root"
-	if def.SourceProfile != expectedSourceProfile {
-		t.Fatalf("Expected '%s', got '%s'", expectedSourceProfile, def.SourceProfile)
-	}
+		expectedSourceProfile := "root"
+		if def.SourceProfile != expectedSourceProfile {
+			t.Fatalf("Expected '%s', got '%s'", expectedSourceProfile, def.SourceProfile)
+		}
 
-	configLoader := &vault.ConfigLoader{File: configFile}
-	config, err := configLoader.GetProfileConfig("foo")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
+		configLoader := &vault.ConfigLoader{File: configFile}
+		config, err := configLoader.GetProfileConfig("foo")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
 
-	expectedSourceProfileName := "root"
-	if config.SourceProfileName != expectedSourceProfileName {
-		t.Fatalf("Expected '%s', got '%s'", expectedSourceProfileName, config.SourceProfileName)
-	}
+		expectedSourceProfileName := "root"
+		if config.SourceProfileName != expectedSourceProfileName {
+			t.Fatalf("Expected '%s', got '%s'", expectedSourceProfileName, config.SourceProfileName)
+		}
+	})
 }
 
 func TestSetSessionTags(t *testing.T) {
@@ -490,83 +528,88 @@ func TestSetTransitiveSessionTags(t *testing.T) {
 }
 
 func TestSessionTaggingFromIni(t *testing.T) {
-	os.Unsetenv("AWS_SESSION_TAGS")
-	os.Unsetenv("AWS_TRANSITIVE_TAGS")
-	f := newConfigFile(t, []byte(`
+	testBothParsers(t, func(t *testing.T) {
+		os.Unsetenv("AWS_SESSION_TAGS")
+		os.Unsetenv("AWS_TRANSITIVE_TAGS")
+		f := newConfigFile(t, []byte(`
 [profile tagged]
 session_tags = tag1 = value1 , tag2=value2 ,tag3=value3
 transitive_session_tags = tagOne ,tagTwo,tagThree
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
-	config, err := configLoader.GetProfileConfig("tagged")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
-	expectedSessionTags := map[string]string{
-		"tag1": "value1",
-		"tag2": "value2",
-		"tag3": "value3",
-	}
-	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
-		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
+		config, err := configLoader.GetProfileConfig("tagged")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
+		expectedSessionTags := map[string]string{
+			"tag1": "value1",
+			"tag2": "value2",
+			"tag3": "value3",
+		}
+		if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+			t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+		}
 
-	expectedTransitiveSessionTags := []string{"tagOne", "tagTwo", "tagThree"}
-	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
-		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
-	}
+		expectedTransitiveSessionTags := []string{"tagOne", "tagTwo", "tagThree"}
+		if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+			t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+		}
+	})
 }
 
 func TestSessionTaggingFromEnvironment(t *testing.T) {
-	os.Setenv("AWS_SESSION_TAGS", " tagA = val1 , tagB=val2 ,tagC=val3")
-	os.Setenv("AWS_TRANSITIVE_TAGS", " tagD ,tagE")
-	defer os.Unsetenv("AWS_SESSION_TAGS")
-	defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
+	testBothParsers(t, func(t *testing.T) {
+		os.Setenv("AWS_SESSION_TAGS", " tagA = val1 , tagB=val2 ,tagC=val3")
+		os.Setenv("AWS_TRANSITIVE_TAGS", " tagD ,tagE")
+		defer os.Unsetenv("AWS_SESSION_TAGS")
+		defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
 
-	f := newConfigFile(t, []byte(`
+		f := newConfigFile(t, []byte(`
 [profile tagged]
 session_tags = tag1 = value1 , tag2=value2 ,tag3=value3
 transitive_session_tags = tagOne ,tagTwo,tagThree
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
-	config, err := configLoader.GetProfileConfig("tagged")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
-	expectedSessionTags := map[string]string{
-		"tagA": "val1",
-		"tagB": "val2",
-		"tagC": "val3",
-	}
-	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
-		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "tagged"}
+		config, err := configLoader.GetProfileConfig("tagged")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
+		expectedSessionTags := map[string]string{
+			"tagA": "val1",
+			"tagB": "val2",
+			"tagC": "val3",
+		}
+		if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+			t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+		}
 
-	expectedTransitiveSessionTags := []string{"tagD", "tagE"}
-	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
-		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
-	}
+		expectedTransitiveSessionTags := []string{"tagD", "tagE"}
+		if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+			t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+		}
+	})
 }
 
 func TestSessionTaggingFromEnvironmentChainedRoles(t *testing.T) {
-	os.Setenv("AWS_SESSION_TAGS", "tagI=valI")
-	os.Setenv("AWS_TRANSITIVE_TAGS", " tagII")
-	defer os.Unsetenv("AWS_SESSION_TAGS")
-	defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
+	testBothParsers(t, func(t *testing.T) {
+		os.Setenv("AWS_SESSION_TAGS", "tagI=valI")
+		os.Setenv("AWS_TRANSITIVE_TAGS", " tagII")
+		defer os.Unsetenv("AWS_SESSION_TAGS")
+		defer os.Unsetenv("AWS_TRANSITIVE_TAGS")
 
-	f := newConfigFile(t, []byte(`
+		f := newConfigFile(t, []byte(`
 [profile base]
 
 [profile interim]
@@ -579,416 +622,451 @@ session_tags=tagA=valueA
 transitive_session_tags=tagB
 source_profile = interim
 `))
-	defer os.Remove(f)
+		defer os.Remove(f)
 
-	configFile, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "target"}
-	config, err := configLoader.GetProfileConfig("target")
-	if err != nil {
-		t.Fatalf("Should have found a profile: %v", err)
-	}
+		configFile, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: "target"}
+		config, err := configLoader.GetProfileConfig("target")
+		if err != nil {
+			t.Fatalf("Should have found a profile: %v", err)
+		}
 
-	// Testing target profile, should have values populated from environment variables
-	expectedSessionTags := map[string]string{"tagI": "valI"}
-	if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
-		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
-	}
+		// Testing target profile, should have values populated from environment variables
+		expectedSessionTags := map[string]string{"tagI": "valI"}
+		if !reflect.DeepEqual(expectedSessionTags, config.SessionTags) {
+			t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, config.SessionTags)
+		}
 
-	expectedTransitiveSessionTags := []string{"tagII"}
-	if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
-		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
-	}
+		expectedTransitiveSessionTags := []string{"tagII"}
+		if !reflect.DeepEqual(expectedTransitiveSessionTags, config.TransitiveSessionTags) {
+			t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, config.TransitiveSessionTags)
+		}
 
-	// Testing interim profile, parameters should come from the config, not environment
-	interimConfig := config.SourceProfile
-	expectedSessionTags = map[string]string{"tag1": "value1"}
-	if !reflect.DeepEqual(expectedSessionTags, interimConfig.SessionTags) {
-		t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, interimConfig.SessionTags)
-	}
+		// Testing interim profile, parameters should come from the config, not environment
+		interimConfig := config.SourceProfile
+		expectedSessionTags = map[string]string{"tag1": "value1"}
+		if !reflect.DeepEqual(expectedSessionTags, interimConfig.SessionTags) {
+			t.Fatalf("Expected session_tags: %+v, got %+v", expectedSessionTags, interimConfig.SessionTags)
+		}
 
-	expectedTransitiveSessionTags = []string{"tag2"}
-	if !reflect.DeepEqual(expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags) {
-		t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags)
-	}
+		expectedTransitiveSessionTags = []string{"tag2"}
+		if !reflect.DeepEqual(expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags) {
+			t.Fatalf("Expected transitive_session_tags: %+v, got %+v", expectedTransitiveSessionTags, interimConfig.TransitiveSessionTags)
+		}
 
-	// Testing base profile, should have empty parameters
-	baseConfig := interimConfig.SourceProfile
-	if len(baseConfig.SessionTags) > 0 {
-		t.Fatalf("Expected session_tags to be empty, got %+v", baseConfig.SessionTags)
-	}
+		// Testing base profile, should have empty parameters
+		baseConfig := interimConfig.SourceProfile
+		if len(baseConfig.SessionTags) > 0 {
+			t.Fatalf("Expected session_tags to be empty, got %+v", baseConfig.SessionTags)
+		}
 
-	if len(baseConfig.TransitiveSessionTags) > 0 {
-		t.Fatalf("Expected transitive_session_tags to be empty, got %+v", baseConfig.TransitiveSessionTags)
-	}
+		if len(baseConfig.TransitiveSessionTags) > 0 {
+			t.Fatalf("Expected transitive_session_tags to be empty, got %+v", baseConfig.TransitiveSessionTags)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
 // Parser correctness tests
 //
-// These document the exact behaviour of the ini.v1-based parser for AWS
-// config file inputs.  They serve as a regression baseline so that any future
-// parser swap can compare results directly.
+// These document the exact behaviour of both parsers for AWS config file
+// inputs.  They run against both the ini.v1 and custom parsers via
+// testBothParsers, except for the two tests that document known divergence
+// between the parsers (those opt in to the custom parser explicitly).
 // ---------------------------------------------------------------------------
 
 // TestParserInlineHashComment verifies that a " #" sequence strips the rest of
 // a value as a comment, matching the SpaceBeforeInlineComment option.
 func TestParserInlineHashComment(t *testing.T) {
-	cases := []struct{ input, want string }{
-		{"region = us-east-1 # prod", "us-east-1"},
-		{"region = us-east-1  # extra space", "us-east-1"},
-		{"region = us-east-1 #no-space-after", "us-east-1"},
-		{"region = us-east-1 #", "us-east-1"},
-	}
-	for _, tc := range cases {
-		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
-		defer os.Remove(f)
-		cfg, err := vault.LoadConfig(f)
-		if err != nil {
-			t.Fatalf("%q: load error: %v", tc.input, err)
+	testBothParsers(t, func(t *testing.T) {
+		cases := []struct{ input, want string }{
+			{"region = us-east-1 # prod", "us-east-1"},
+			{"region = us-east-1  # extra space", "us-east-1"},
+			{"region = us-east-1 #no-space-after", "us-east-1"},
+			{"region = us-east-1 #", "us-east-1"},
 		}
-		p, _ := cfg.ProfileSection("p")
-		if p.Region != tc.want {
-			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		for _, tc := range cases {
+			f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+			defer os.Remove(f)
+			cfg, err := vault.LoadConfig(f)
+			if err != nil {
+				t.Fatalf("%q: load error: %v", tc.input, err)
+			}
+			p, _ := cfg.ProfileSection("p")
+			if p.Region != tc.want {
+				t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+			}
 		}
-	}
+	})
 }
 
 // TestParserInlineSemicolonComment verifies that " ;" strips a trailing
 // semicolon comment, matching SpaceBeforeInlineComment behaviour.
 func TestParserInlineSemicolonComment(t *testing.T) {
-	cases := []struct{ input, want string }{
-		{"region = us-east-1 ; prod region", "us-east-1"},
-		{"region = us-east-1 ;", "us-east-1"},
-	}
-	for _, tc := range cases {
-		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
-		defer os.Remove(f)
-		cfg, err := vault.LoadConfig(f)
-		if err != nil {
-			t.Fatalf("%q: load error: %v", tc.input, err)
+	testBothParsers(t, func(t *testing.T) {
+		cases := []struct{ input, want string }{
+			{"region = us-east-1 ; prod region", "us-east-1"},
+			{"region = us-east-1 ;", "us-east-1"},
 		}
-		p, _ := cfg.ProfileSection("p")
-		if p.Region != tc.want {
-			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		for _, tc := range cases {
+			f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+			defer os.Remove(f)
+			cfg, err := vault.LoadConfig(f)
+			if err != nil {
+				t.Fatalf("%q: load error: %v", tc.input, err)
+			}
+			p, _ := cfg.ProfileSection("p")
+			if p.Region != tc.want {
+				t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+			}
 		}
-	}
+	})
 }
 
 // TestParserHashWithoutSpacePreserved verifies that "#" not preceded by a
 // space is kept as part of the value — important for URLs and ARNs.
 func TestParserHashWithoutSpacePreserved(t *testing.T) {
-	cases := []struct{ input, want string }{
-		{"endpoint_url = https://example.com/path#anchor", "https://example.com/path#anchor"},
-		{"endpoint_url = https://example.com#", "https://example.com#"},
-		{"role_session_name = foo#bar", "foo#bar"},
-	}
-	for _, tc := range cases {
-		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
-		defer os.Remove(f)
-		cfg, err := vault.LoadConfig(f)
-		if err != nil {
-			t.Fatalf("%q: load error: %v", tc.input, err)
+	testBothParsers(t, func(t *testing.T) {
+		cases := []struct{ input, want string }{
+			{"endpoint_url = https://example.com/path#anchor", "https://example.com/path#anchor"},
+			{"endpoint_url = https://example.com#", "https://example.com#"},
+			{"role_session_name = foo#bar", "foo#bar"},
 		}
-		p, _ := cfg.ProfileSection("p")
-		got := p.EndpointURL + p.RoleSessionName // one of the two will be populated
-		if got != tc.want {
-			t.Errorf("%q: want %q, got %q", tc.input, tc.want, got)
+		for _, tc := range cases {
+			f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+			defer os.Remove(f)
+			cfg, err := vault.LoadConfig(f)
+			if err != nil {
+				t.Fatalf("%q: load error: %v", tc.input, err)
+			}
+			p, _ := cfg.ProfileSection("p")
+			got := p.EndpointURL + p.RoleSessionName // one of the two will be populated
+			if got != tc.want {
+				t.Errorf("%q: want %q, got %q", tc.input, tc.want, got)
+			}
 		}
-	}
+	})
 }
 
 // TestParserSemicolonWithoutSpacePreserved verifies that ";" not preceded by a
 // space stays in the value.
 func TestParserSemicolonWithoutSpacePreserved(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 role_session_name = foo;bar
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.RoleSessionName != "foo;bar" {
-		t.Errorf("want %q, got %q", "foo;bar", p.RoleSessionName)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.RoleSessionName != "foo;bar" {
+			t.Errorf("want %q, got %q", "foo;bar", p.RoleSessionName)
+		}
+	})
 }
 
 // TestParserSectionHeaderWithComment verifies that a comment after the closing
 // "]" of a section header does not prevent the section from being recognised.
 func TestParserSectionHeaderWithComment(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p] # production account
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p] # production account
 region = us-east-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("expected profile 'p' to be parsed despite comment on section header")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q, got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("expected profile 'p' to be parsed despite comment on section header")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q, got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserEmptyValue verifies that "key =" (empty value) is stored as an
 // empty string rather than omitted.
 func TestParserEmptyValue(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 role_arn =
 region = us-east-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.RoleARN != "" {
-		t.Errorf("want empty role_arn, got %q", p.RoleARN)
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q, got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.RoleARN != "" {
+			t.Errorf("want empty role_arn, got %q", p.RoleARN)
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q, got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserMixedCaseKeys verifies that key names are normalised to lower-case
 // regardless of how they appear in the file (InsensitiveKeys: true).
 func TestParserMixedCaseKeys(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 REGION = us-east-1
 Role_Arn = arn:aws:iam::123:role/Admin
 MFA_Serial = arn:aws:iam::123:mfa/user
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.Region != "us-east-1" {
-		t.Errorf("REGION: want %q, got %q", "us-east-1", p.Region)
-	}
-	if p.RoleARN != "arn:aws:iam::123:role/Admin" {
-		t.Errorf("Role_Arn: want arn, got %q", p.RoleARN)
-	}
-	if p.MfaSerial != "arn:aws:iam::123:mfa/user" {
-		t.Errorf("MFA_Serial: want arn, got %q", p.MfaSerial)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != "us-east-1" {
+			t.Errorf("REGION: want %q, got %q", "us-east-1", p.Region)
+		}
+		if p.RoleARN != "arn:aws:iam::123:role/Admin" {
+			t.Errorf("Role_Arn: want arn, got %q", p.RoleARN)
+		}
+		if p.MfaSerial != "arn:aws:iam::123:mfa/user" {
+			t.Errorf("MFA_Serial: want arn, got %q", p.MfaSerial)
+		}
+	})
 }
 
 // TestParserWhitespaceTrimmedAroundValue verifies that leading and trailing
 // spaces around a value are stripped.
 func TestParserWhitespaceTrimmedAroundValue(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region   =   ap-southeast-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.Region != "ap-southeast-1" {
-		t.Errorf("want %q, got %q", "ap-southeast-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != "ap-southeast-1" {
+			t.Errorf("want %q, got %q", "ap-southeast-1", p.Region)
+		}
+	})
 }
 
 // TestParserValueContainingEquals verifies that only the first "=" is the
 // key-value delimiter — subsequent "=" are part of the value.
 func TestParserValueContainingEquals(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 credential_process = aws-vault export --format=json --no-session
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	want := "aws-vault export --format=json --no-session"
-	if p.CredentialProcess != want {
-		t.Errorf("want %q, got %q", want, p.CredentialProcess)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		want := "aws-vault export --format=json --no-session"
+		if p.CredentialProcess != want {
+			t.Errorf("want %q, got %q", want, p.CredentialProcess)
+		}
+	})
 }
 
 // TestParserARNValue verifies that ARN strings (which contain ":" separators)
 // are preserved verbatim.  ini.v1 uses "=:" as key-value delimiters, so the
 // first "=" stops key scanning before any ":" in the value is reached.
 func TestParserARNValue(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 role_arn = arn:aws:iam::123456789012:role/MyRole
 mfa_serial = arn:aws:iam::123456789012:mfa/myuser
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	wantARN := "arn:aws:iam::123456789012:role/MyRole"
-	if p.RoleARN != wantARN {
-		t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
-	}
-	wantMFA := "arn:aws:iam::123456789012:mfa/myuser"
-	if p.MfaSerial != wantMFA {
-		t.Errorf("mfa_serial: want %q, got %q", wantMFA, p.MfaSerial)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		wantARN := "arn:aws:iam::123456789012:role/MyRole"
+		if p.RoleARN != wantARN {
+			t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
+		}
+		wantMFA := "arn:aws:iam::123456789012:mfa/myuser"
+		if p.MfaSerial != wantMFA {
+			t.Errorf("mfa_serial: want %q, got %q", wantMFA, p.MfaSerial)
+		}
+	})
 }
 
 // TestParserLargeNumberPreserved verifies that very large numeric strings are
 // kept as-is and not truncated or converted.
 func TestParserLargeNumberPreserved(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 role_session_name = 1234567890123456789012345678901234567890
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	want := "1234567890123456789012345678901234567890"
-	if p.RoleSessionName != want {
-		t.Errorf("want %q, got %q", want, p.RoleSessionName)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		want := "1234567890123456789012345678901234567890"
+		if p.RoleSessionName != want {
+			t.Errorf("want %q, got %q", want, p.RoleSessionName)
+		}
+	})
 }
 
 // TestParserNestedValuesSkippedForProfileFields verifies that indented
 // sub-property lines (AllowNestedValues) do not surface as profile fields —
 // aws-vault does not read s3, http_proxy, or other nested sections.
 func TestParserNestedValuesSkippedForProfileFields(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region = us-west-2
 s3 =
   max_concurrent_requests = 10
   max_queue_size = 1000
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.Region != "us-west-2" {
-		t.Errorf("want %q, got %q", "us-west-2", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.Region != "us-west-2" {
+			t.Errorf("want %q, got %q", "us-west-2", p.Region)
+		}
+	})
 }
 
 // TestParserPreSectionKeysIgnored verifies that key=value lines appearing
 // before any section header are silently discarded.
 func TestParserPreSectionKeysIgnored(t *testing.T) {
-	f := newConfigFile(t, []byte(`region = us-east-1
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`region = us-east-1
 [profile p]
 region = eu-west-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.Region != "eu-west-1" {
-		t.Errorf("want %q, got %q", "eu-west-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != "eu-west-1" {
+			t.Errorf("want %q, got %q", "eu-west-1", p.Region)
+		}
+	})
 }
 
 // TestParserDuplicateSectionsMerged verifies that when the same section name
 // appears more than once its keys are merged, and ProfileSections() lists it
 // only once.
 func TestParserDuplicateSectionsMerged(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region = us-east-1
 
 [profile p]
 role_arn = arn:aws:iam::123:role/Admin
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
-	}
-	if p.RoleARN != "arn:aws:iam::123:role/Admin" {
-		t.Errorf("role_arn: want arn, got %q", p.RoleARN)
-	}
-	count := 0
-	for _, s := range cfg.ProfileSections() {
-		if s.Name == "p" {
-			count++
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
-	if count != 1 {
-		t.Errorf("want profile 'p' once in ProfileSections(), got %d", count)
-	}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
+		}
+		if p.RoleARN != "arn:aws:iam::123:role/Admin" {
+			t.Errorf("role_arn: want arn, got %q", p.RoleARN)
+		}
+		count := 0
+		for _, s := range cfg.ProfileSections() {
+			if s.Name == "p" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("want profile 'p' once in ProfileSections(), got %d", count)
+		}
+	})
 }
 
 // TestParserDuplicateKeyLastValueWins verifies that when a key appears more
 // than once in the same section, the last value is used.
 func TestParserDuplicateKeyLastValueWins(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region = us-east-1
 region = eu-west-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.Region != "eu-west-1" {
-		t.Errorf("want last value %q, got %q", "eu-west-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != "eu-west-1" {
+			t.Errorf("want last value %q, got %q", "eu-west-1", p.Region)
+		}
+	})
 }
 
 // TestParserDeclarationOrderPreserved verifies that ProfileSections() returns
 // profiles in the order they appear in the file.
 func TestParserDeclarationOrderPreserved(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile alpha]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile alpha]
 region = us-east-1
 [profile beta]
 region = us-west-2
 [profile gamma]
 region = eu-west-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sections := cfg.ProfileSections()
-	names := make([]string, len(sections))
-	for i, s := range sections {
-		names[i] = s.Name
-	}
-	want := []string{"alpha", "beta", "gamma"}
-	if !reflect.DeepEqual(want, names) {
-		t.Errorf("want order %v, got %v", want, names)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sections := cfg.ProfileSections()
+		names := make([]string, len(sections))
+		for i, s := range sections {
+			names[i] = s.Name
+		}
+		want := []string{"alpha", "beta", "gamma"}
+		if !reflect.DeepEqual(want, names) {
+			t.Errorf("want order %v, got %v", want, names)
+		}
+	})
 }
 
 // TestParserAllSectionTypes verifies that [default], [profile name] and
 // [sso-session name] are all correctly identified and accessible.
 func TestParserAllSectionTypes(t *testing.T) {
-	f := newConfigFile(t, []byte(`[default]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[default]
 region = us-east-1
 
 [profile myprofile]
@@ -1000,52 +1078,55 @@ sso_start_url = https://myorg.awsapps.com/start
 sso_region = us-east-1
 sso_registration_scopes = sso:account:access
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	def, ok := cfg.ProfileSection("default")
-	if !ok || def.Region != "us-east-1" {
-		t.Errorf("default: want region us-east-1, got %q (ok=%v)", def.Region, ok)
-	}
+		def, ok := cfg.ProfileSection("default")
+		if !ok || def.Region != "us-east-1" {
+			t.Errorf("default: want region us-east-1, got %q (ok=%v)", def.Region, ok)
+		}
 
-	prof, ok := cfg.ProfileSection("myprofile")
-	if !ok || prof.SSOSession != "myorg" {
-		t.Errorf("myprofile: want sso_session myorg, got %q (ok=%v)", prof.SSOSession, ok)
-	}
+		prof, ok := cfg.ProfileSection("myprofile")
+		if !ok || prof.SSOSession != "myorg" {
+			t.Errorf("myprofile: want sso_session myorg, got %q (ok=%v)", prof.SSOSession, ok)
+		}
 
-	sso, ok := cfg.SSOSessionSection("myorg")
-	if !ok || sso.SSOStartURL != "https://myorg.awsapps.com/start" {
-		t.Errorf("sso-session: want start url, got %q (ok=%v)", sso.SSOStartURL, ok)
-	}
-	if sso.SSORegistrationScopes != "sso:account:access" {
-		t.Errorf("sso-session: want registration scopes, got %q", sso.SSORegistrationScopes)
-	}
+		sso, ok := cfg.SSOSessionSection("myorg")
+		if !ok || sso.SSOStartURL != "https://myorg.awsapps.com/start" {
+			t.Errorf("sso-session: want start url, got %q (ok=%v)", sso.SSOStartURL, ok)
+		}
+		if sso.SSORegistrationScopes != "sso:account:access" {
+			t.Errorf("sso-session: want registration scopes, got %q", sso.SSORegistrationScopes)
+		}
+	})
 }
 
 // TestParserCommentOnlyLines verifies that lines starting with "#" or ";" are
 // treated as comments regardless of surrounding content.
 func TestParserCommentOnlyLines(t *testing.T) {
-	f := newConfigFile(t, []byte(`# full-line hash comment
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`# full-line hash comment
 [profile p]
 ; full-line semicolon comment
 region = us-east-1
 # trailing comment
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q, got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q, got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserQuotedValueStripped verifies ini.v1's default behaviour of
@@ -1053,19 +1134,21 @@ region = us-east-1
 // Note: the AWS SDK parser does NOT strip quotes — this is an ini.v1-specific
 // behaviour that a replacement parser must handle explicitly or document.
 func TestParserQuotedValueStripped(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region = "us-east-1"
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	// ini.v1 strips surrounding double-quotes by default.
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q (quotes stripped), got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		// ini.v1 strips surrounding double-quotes by default.
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q (quotes stripped), got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserTabBeforeCommentNotStripped documents that ini.v1 with
@@ -1075,23 +1158,25 @@ region = "us-east-1"
 // The AWS SDK treats any whitespace (space OR tab) before a comment character
 // as a valid separator — this is an important divergence for hand-edited files.
 func TestParserTabBeforeCommentNotStripped(t *testing.T) {
-	cases := []struct{ input, want string }{
-		{"region = us-east-1\t# comment", "us-east-1\t# comment"},
-		{"region = us-east-1\t\t# comment", "us-east-1\t\t# comment"},
-		{"region = us-east-1\t; comment", "us-east-1\t; comment"},
-	}
-	for _, tc := range cases {
-		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
-		defer os.Remove(f)
-		cfg, err := vault.LoadConfig(f)
-		if err != nil {
-			t.Fatalf("%q: load error: %v", tc.input, err)
+	testBothParsers(t, func(t *testing.T) {
+		cases := []struct{ input, want string }{
+			{"region = us-east-1\t# comment", "us-east-1\t# comment"},
+			{"region = us-east-1\t\t# comment", "us-east-1\t\t# comment"},
+			{"region = us-east-1\t; comment", "us-east-1\t; comment"},
 		}
-		p, _ := cfg.ProfileSection("p")
-		if p.Region != tc.want {
-			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		for _, tc := range cases {
+			f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+			defer os.Remove(f)
+			cfg, err := vault.LoadConfig(f)
+			if err != nil {
+				t.Fatalf("%q: load error: %v", tc.input, err)
+			}
+			p, _ := cfg.ProfileSection("p")
+			if p.Region != tc.want {
+				t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+			}
 		}
-	}
+	})
 }
 
 // TestParserSpacesInsideSectionBracketsNotTrimmed documents that ini.v1 does
@@ -1100,16 +1185,18 @@ func TestParserTabBeforeCommentNotStripped(t *testing.T) {
 // preserved), so ProfileSection("foo") — which looks up "profile foo" — returns
 // false.  The AWS SDK DOES trim this whitespace, making the lookup succeed.
 func TestParserSpacesInsideSectionBracketsNotTrimmed(t *testing.T) {
-	f := newConfigFile(t, []byte("[ profile foo ]\nregion = us-east-1\n"))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, ok := cfg.ProfileSection("foo")
-	if ok {
-		t.Error("ini.v1 preserves spaces inside brackets, so lookup for 'foo' should fail")
-	}
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte("[ profile foo ]\nregion = us-east-1\n"))
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := cfg.ProfileSection("foo")
+		if ok {
+			t.Error("ini.v1 preserves spaces inside brackets, so lookup for 'foo' should fail")
+		}
+	})
 }
 
 // TestParserValueStartingWithHashPreserved documents the boundary condition
@@ -1119,24 +1206,26 @@ func TestParserSpacesInsideSectionBracketsNotTrimmed(t *testing.T) {
 // a comment — it stays in the value.
 // Contrast with the AWS SDK, which returns "" for "i = # comment".
 func TestParserValueStartingWithHashPreserved(t *testing.T) {
-	cases := []struct {
-		key, input, want string
-	}{
-		{"region", "region = # a note", "# a note"},
-		{"region", "region = ; a note", "; a note"},
-	}
-	for _, tc := range cases {
-		f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
-		defer os.Remove(f)
-		cfg, err := vault.LoadConfig(f)
-		if err != nil {
-			t.Fatalf("%q: load error: %v", tc.input, err)
+	testBothParsers(t, func(t *testing.T) {
+		cases := []struct {
+			key, input, want string
+		}{
+			{"region", "region = # a note", "# a note"},
+			{"region", "region = ; a note", "; a note"},
 		}
-		p, _ := cfg.ProfileSection("p")
-		if p.Region != tc.want {
-			t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+		for _, tc := range cases {
+			f := newConfigFile(t, []byte("[profile p]\n"+tc.input+"\n"))
+			defer os.Remove(f)
+			cfg, err := vault.LoadConfig(f)
+			if err != nil {
+				t.Fatalf("%q: load error: %v", tc.input, err)
+			}
+			p, _ := cfg.ProfileSection("p")
+			if p.Region != tc.want {
+				t.Errorf("%q: want %q, got %q", tc.input, tc.want, p.Region)
+			}
 		}
-	}
+	})
 }
 
 // TestParserColonKeyValueDelimiter documents that ini.v1 accepts ":" as a
@@ -1146,86 +1235,95 @@ func TestParserValueStartingWithHashPreserved(t *testing.T) {
 // lines.  In practice AWS configs use "=" exclusively, but the contract should
 // be explicit.
 func TestParserColonKeyValueDelimiter(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region: us-east-1
 role_arn: arn:aws:iam::123456789012:role/MyRole
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
-	}
-	// role_arn: arn:aws:... — the first ":" splits key from value, leaving
-	// " arn:aws:iam::..." as the value (colons in ARNs are safe because they
-	// come AFTER the key delimiter).
-	wantARN := "arn:aws:iam::123456789012:role/MyRole"
-	if p.RoleARN != wantARN {
-		t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("region: want %q, got %q", "us-east-1", p.Region)
+		}
+		// role_arn: arn:aws:... — the first ":" splits key from value, leaving
+		// " arn:aws:iam::..." as the value (colons in ARNs are safe because they
+		// come AFTER the key delimiter).
+		wantARN := "arn:aws:iam::123456789012:role/MyRole"
+		if p.RoleARN != wantARN {
+			t.Errorf("role_arn: want %q, got %q", wantARN, p.RoleARN)
+		}
+	})
 }
 
 // TestParserSingleQuotedValueStripped verifies that ini.v1 strips matching
 // surrounding single-quotes as well as double-quotes.
 // Note: the AWS SDK preserves quotes — this is an ini.v1-specific behaviour.
 func TestParserSingleQuotedValueStripped(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 region = 'us-east-1'
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, _ := cfg.ProfileSection("p")
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q (single quotes stripped), got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := cfg.ProfileSection("p")
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q (single quotes stripped), got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserEmptyFile verifies that LoadConfig on a zero-byte file succeeds and
 // returns no profile sections.
 func TestParserEmptyFile(t *testing.T) {
-	f := newConfigFile(t, []byte{})
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatalf("unexpected error on empty file: %v", err)
-	}
-	if sections := cfg.ProfileSections(); len(sections) != 0 {
-		t.Errorf("want 0 sections, got %d: %v", len(sections), sections)
-	}
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte{})
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("unexpected error on empty file: %v", err)
+		}
+		if sections := cfg.ProfileSections(); len(sections) != 0 {
+			t.Errorf("want 0 sections, got %d: %v", len(sections), sections)
+		}
+	})
 }
 
 // TestParserFileWithoutTrailingNewline verifies that a config file whose last
 // line is not terminated by a newline is parsed correctly.
 func TestParserFileWithoutTrailingNewline(t *testing.T) {
-	f := newConfigFile(t, []byte("[profile p]\nregion=us-east-1")) // no trailing \n
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q, got %q", "us-east-1", p.Region)
-	}
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte("[profile p]\nregion=us-east-1")) // no trailing \n
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q, got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserServicesSectionNotInProfileSections verifies that [services name]
 // sections (used by the AWS CLI for endpoint customisation) are not returned by
 // ProfileSections().
 func TestParserServicesSectionNotInProfileSections(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile myprofile]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile myprofile]
 region = us-east-1
 
 [services my-endpoints]
@@ -1235,63 +1333,68 @@ s3 =
 [profile another]
 region = us-west-2
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sections := cfg.ProfileSections()
-	for _, s := range sections {
-		if strings.Contains(s.Name, "services") {
-			t.Errorf("services section must not appear in ProfileSections(), got %q", s.Name)
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
-	if len(sections) != 2 {
-		t.Errorf("want 2 profile sections, got %d: %v", len(sections), sections)
-	}
+		sections := cfg.ProfileSections()
+		for _, s := range sections {
+			if strings.Contains(s.Name, "services") {
+				t.Errorf("services section must not appear in ProfileSections(), got %q", s.Name)
+			}
+		}
+		if len(sections) != 2 {
+			t.Errorf("want 2 profile sections, got %d: %v", len(sections), sections)
+		}
+	})
 }
 
 // TestParserSectionHeaderWithSemicolonComment extends
 // TestParserSectionHeaderWithComment to verify that a semicolon comment after
 // the closing "]" is also handled correctly.
 func TestParserSectionHeaderWithSemicolonComment(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p] ; production account
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p] ; production account
 region = us-east-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("expected profile 'p' to be parsed despite semicolon comment on section header")
-	}
-	if p.Region != "us-east-1" {
-		t.Errorf("want %q, got %q", "us-east-1", p.Region)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("expected profile 'p' to be parsed despite semicolon comment on section header")
+		}
+		if p.Region != "us-east-1" {
+			t.Errorf("want %q, got %q", "us-east-1", p.Region)
+		}
+	})
 }
 
 // TestParserDurationSecondsEmpty verifies that an empty duration_seconds value
 // ("duration_seconds =") does not cause a parse error and results in the zero
 // uint value (treated as unset).
 func TestParserDurationSecondsEmpty(t *testing.T) {
-	f := newConfigFile(t, []byte(`[profile p]
+	testBothParsers(t, func(t *testing.T) {
+		f := newConfigFile(t, []byte(`[profile p]
 duration_seconds =
 region = us-east-1
 `))
-	defer os.Remove(f)
-	cfg, err := vault.LoadConfig(f)
-	if err != nil {
-		t.Fatalf("unexpected load error: %v", err)
-	}
-	p, ok := cfg.ProfileSection("p")
-	if !ok {
-		t.Fatal("profile not found")
-	}
-	if p.DurationSeconds != 0 {
-		t.Errorf("want DurationSeconds=0 for empty value, got %d", p.DurationSeconds)
-	}
+		defer os.Remove(f)
+		cfg, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("unexpected load error: %v", err)
+		}
+		p, ok := cfg.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile not found")
+		}
+		if p.DurationSeconds != 0 {
+			t.Errorf("want DurationSeconds=0 for empty value, got %d", p.DurationSeconds)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -1328,7 +1431,7 @@ func BenchmarkParseSmallConfig(b *testing.B) {
 }
 
 func BenchmarkParseLargeSyntheticConfig(b *testing.B) {
-	path := generateLargeConfig(b, 87000)
+	path := generateLargeConfig(b, 100000)
 	defer os.Remove(path)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1395,4 +1498,194 @@ func BenchmarkProfileSections(b *testing.B) {
 		sections := cfg.ProfileSections()
 		_ = sections
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for bugs fixed after the initial parser replacement
+// ---------------------------------------------------------------------------
+
+// TestAddUpdatesExistingProfile verifies that calling Add() for a profile that
+// already exists replaces it rather than appending a duplicate section block.
+func TestAddUpdatesExistingProfile(t *testing.T) {
+	testBothParsers(t, func(t *testing.T) {
+		cfg := []byte("[default]\nregion=us-west-2\n\n[profile user2]\nregion=us-east-1\n")
+		f := newConfigFile(t, cfg)
+		defer os.Remove(f)
+
+		c, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = c.Add(vault.ProfileSection{
+			Name:      "user2",
+			Region:    "eu-west-1",
+			MfaSerial: "arn:aws:iam::123:mfa/user",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// In-memory lookup must reflect updated values immediately.
+		p, ok := c.ProfileSection("user2")
+		if !ok {
+			t.Fatal("profile user2 not found in memory after Add()")
+		}
+		if p.Region != "eu-west-1" {
+			t.Errorf("Region: want eu-west-1, got %q", p.Region)
+		}
+		if p.MfaSerial != "arn:aws:iam::123:mfa/user" {
+			t.Errorf("MfaSerial: want arn:aws:iam::123:mfa/user, got %q", p.MfaSerial)
+		}
+
+		// Saved file must have exactly one [profile user2] header.
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count := bytes.Count(b, []byte("[profile user2]")); count != 1 {
+			t.Errorf("file has %d [profile user2] headers, want 1\n%s", count, b)
+		}
+
+		// After re-loading from disk the values must still be correct.
+		c2, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p2, ok2 := c2.ProfileSection("user2")
+		if !ok2 {
+			t.Fatal("profile user2 not found after re-load")
+		}
+		if p2.Region != "eu-west-1" {
+			t.Errorf("after reload — Region: want eu-west-1, got %q", p2.Region)
+		}
+	})
+}
+
+// TestParserCRLFLineEndings verifies that Windows-style \r\n line endings are
+// handled correctly; the \r must not bleed into section names or values.
+func TestParserCRLFLineEndings(t *testing.T) {
+	testBothParsers(t, func(t *testing.T) {
+		cfg := "[default]\r\nregion=us-east-1\r\n\r\n[profile p]\r\nrole_arn=arn:aws:iam::123:role/R\r\n"
+		f := newConfigFile(t, []byte(cfg))
+		defer os.Remove(f)
+
+		c, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		def, ok := c.ProfileSection("default")
+		if !ok {
+			t.Fatal("default profile not found")
+		}
+		if def.Region != "us-east-1" {
+			t.Errorf("Region: want us-east-1, got %q", def.Region)
+		}
+		p, ok := c.ProfileSection("p")
+		if !ok {
+			t.Fatal("profile p not found")
+		}
+		if p.RoleARN != "arn:aws:iam::123:role/R" {
+			t.Errorf("RoleARN: want arn:aws:iam::123:role/R, got %q", p.RoleARN)
+		}
+	})
+}
+
+// TestParserEmptyKeyIgnored verifies that a line with no key before the
+// delimiter (e.g. "= orphaned") does not panic and is silently dropped.
+// ini.v1 returns an error for empty key names; this behaviour is specific
+// to the custom parser, so the test opts in explicitly.
+func TestParserEmptyKeyIgnored(t *testing.T) {
+	t.Setenv("AWS_VAULT_USE_CUSTOM_INI_PARSER", "true")
+	cfg := "[profile p]\n= orphaned-value\nregion=us-east-1\n"
+	f := newConfigFile(t, []byte(cfg))
+	defer os.Remove(f)
+
+	c, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := c.ProfileSection("p")
+	if p.Region != "us-east-1" {
+		t.Errorf("Region: want us-east-1, got %q", p.Region)
+	}
+}
+
+// TestParserHashInsideQuotedValuePreserved verifies that a '#' character
+// inside a double-quoted value is not treated as an inline comment marker.
+// ini.v1 strips the hash even inside quotes; this is a custom-parser
+// improvement, so the test opts in explicitly.
+func TestParserHashInsideQuotedValuePreserved(t *testing.T) {
+	t.Setenv("AWS_VAULT_USE_CUSTOM_INI_PARSER", "true")
+	cfg := "[profile p]\nregion=\"us-east-1 # not a comment\"\n"
+	f := newConfigFile(t, []byte(cfg))
+	defer os.Remove(f)
+
+	c, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := c.ProfileSection("p")
+	if p.Region != "us-east-1 # not a comment" {
+		t.Errorf("Region: want %q, got %q", "us-east-1 # not a comment", p.Region)
+	}
+}
+
+// TestParserHashAfterClosingQuoteIsComment verifies that a '#' that appears
+// after a closing quote is correctly treated as an inline comment.
+func TestParserHashAfterClosingQuoteIsComment(t *testing.T) {
+	testBothParsers(t, func(t *testing.T) {
+		cfg := "[profile p]\nregion=\"us-east-1\" # actual comment\n"
+		f := newConfigFile(t, []byte(cfg))
+		defer os.Remove(f)
+
+		c, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := c.ProfileSection("p")
+		if p.Region != "us-east-1" {
+			t.Errorf("Region: want us-east-1, got %q", p.Region)
+		}
+	})
+}
+
+// TestParserDuplicateSectionKeyPrecedence verifies that when the same section
+// name appears twice, the second occurrence's value wins for any key that both
+// blocks define.
+func TestParserDuplicateSectionKeyPrecedence(t *testing.T) {
+	testBothParsers(t, func(t *testing.T) {
+		cfg := "[profile p]\nregion=us-east-1\n\n[profile p]\nregion=eu-west-1\n"
+		f := newConfigFile(t, []byte(cfg))
+		defer os.Remove(f)
+
+		c, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, _ := c.ProfileSection("p")
+		if p.Region != "eu-west-1" {
+			t.Errorf("Region: want eu-west-1 (last value wins), got %q", p.Region)
+		}
+	})
+}
+
+// TestParserLongLines verifies that lines exceeding the default 64 KiB
+// bufio.Scanner limit are parsed without error.
+func TestParserLongLines(t *testing.T) {
+	testBothParsers(t, func(t *testing.T) {
+		longValue := strings.Repeat("x", 100*1024) // 100 KiB — above the 64 KiB default
+		cfg := "[profile p]\ncredential_process=" + longValue + "\n"
+		f := newConfigFile(t, []byte(cfg))
+		defer os.Remove(f)
+
+		c, err := vault.LoadConfig(f)
+		if err != nil {
+			t.Fatalf("LoadConfig failed on long line: %v", err)
+		}
+		p, _ := c.ProfileSection("p")
+		if p.CredentialProcess != longValue {
+			t.Errorf("CredentialProcess length: want %d, got %d", len(longValue), len(p.CredentialProcess))
+		}
+	})
 }

--- a/vault/configparser/bench_test.go
+++ b/vault/configparser/bench_test.go
@@ -1,0 +1,186 @@
+// Package-level benchmarks that compare the iniv1 and custom parser backends
+// side-by-side on the same inputs.  Run with:
+//
+//	go test -bench=. -benchmem -count=6 ./vault/configparser/ | tee /tmp/bench.txt
+package configparser_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/byteness/aws-vault/v7/vault/configparser/custom"
+	"github.com/byteness/aws-vault/v7/vault/configparser/iniv1"
+)
+
+// TestMain discards log output from the parser backends so benchmark output
+// is not swamped by "Unrecognised ini file section" messages from iniv1.
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
+
+// smallConfig is a representative config with several profiles.
+const smallConfig = `[default]
+region=us-east-1
+
+[profile dev]
+region=us-west-2
+mfa_serial=arn:aws:iam::123456789012:mfa/user
+
+[profile prod]
+source_profile=dev
+role_arn=arn:aws:iam::999999999999:role/DeployRole
+duration_seconds=3600
+
+[profile sso-user]
+sso_session=my-sso
+sso_account_id=111122223333
+sso_role_name=ReadOnly
+
+[sso-session my-sso]
+sso_start_url=https://d-abc123.awsapps.com/start
+sso_region=us-east-1
+sso_registration_scopes=sso:account:access
+`
+
+func generateLargeConfig(tb testing.TB, n int) string {
+	tb.Helper()
+	f, err := os.CreateTemp("", "aws-config-bench")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	fmt.Fprintf(f, "[default]\nregion=us-east-1\n\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(f, "[profile sso-acct%d]\nsso_account_id=%012d\nsso_role_name=role%d\nsso_start_url=https://d-abc123.awsapps.com/start\nsso_region=us-east-1\nregion=us-east-1\n\n", i, i, i)
+		fmt.Fprintf(f, "[profile exec-acct%d]\ncredential_process=aws-vault export --format=json sso-acct%d\n\n", i, i)
+	}
+	name := f.Name()
+	f.Close()
+	tb.Cleanup(func() { os.Remove(name) })
+	return name
+}
+
+func writeSmallConfig(tb testing.TB) string {
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(smallConfig), 0600); err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+// ── Small config ──────────────────────────────────────────────────────────────
+
+func BenchmarkIniv1ParseSmall(b *testing.B) {
+	path := writeSmallConfig(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := iniv1.New()
+		if err := p.Load(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCustomParseSmall(b *testing.B) {
+	path := writeSmallConfig(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := custom.New()
+		if err := p.Load(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── Large synthetic config (87 k profiles) ───────────────────────────────────
+
+func BenchmarkIniv1ParseLarge(b *testing.B) {
+	path := generateLargeConfig(b, 100000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := iniv1.New()
+		if err := p.Load(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCustomParseLarge(b *testing.B) {
+	path := generateLargeConfig(b, 100000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := custom.New()
+		if err := p.Load(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ── Profile lookup (post-load) ────────────────────────────────────────────────
+
+func BenchmarkIniv1ProfileSectionLookup(b *testing.B) {
+	path := writeSmallConfig(b)
+	p := iniv1.New()
+	if err := p.Load(path); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prof, _ := p.ProfileSection("prod")
+		_ = prof
+	}
+}
+
+func BenchmarkCustomProfileSectionLookup(b *testing.B) {
+	path := writeSmallConfig(b)
+	p := custom.New()
+	if err := p.Load(path); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prof, _ := p.ProfileSection("prod")
+		_ = prof
+	}
+}
+
+// ── ProfileSections() list traversal ─────────────────────────────────────────
+
+func BenchmarkIniv1ProfileSections(b *testing.B) {
+	path := writeSmallConfig(b)
+	p := iniv1.New()
+	if err := p.Load(path); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sections := p.ProfileSections()
+		_ = sections
+	}
+}
+
+func BenchmarkCustomProfileSections(b *testing.B) {
+	path := writeSmallConfig(b)
+	p := custom.New()
+	if err := p.Load(path); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sections := p.ProfileSections()
+		_ = sections
+	}
+}

--- a/vault/configparser/configparser.go
+++ b/vault/configparser/configparser.go
@@ -1,0 +1,65 @@
+// Package configparser defines the Parser interface and the domain types shared
+// by all AWS config file parser implementations.
+package configparser
+
+// DefaultSectionName is the name of the implicit default profile section.
+const DefaultSectionName = "default"
+
+// ProfileSection is a profile section of an AWS config file.
+type ProfileSection struct {
+	Name                    string `ini:"-"`
+	MfaSerial               string `ini:"mfa_serial,omitempty"`
+	RoleARN                 string `ini:"role_arn,omitempty"`
+	ExternalID              string `ini:"external_id,omitempty"`
+	Region                  string `ini:"region,omitempty"`
+	RoleSessionName         string `ini:"role_session_name,omitempty"`
+	DurationSeconds         uint   `ini:"duration_seconds,omitempty"`
+	SourceProfile           string `ini:"source_profile,omitempty"`
+	IncludeProfile          string `ini:"include_profile,omitempty"`
+	SSOSession              string `ini:"sso_session,omitempty"`
+	SSOStartURL             string `ini:"sso_start_url,omitempty"`
+	SSORegion               string `ini:"sso_region,omitempty"`
+	SSOAccountID            string `ini:"sso_account_id,omitempty"`
+	SSORoleName             string `ini:"sso_role_name,omitempty"`
+	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
+	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
+	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
+	EndpointURL             string `ini:"endpoint_url,omitempty"`
+	SessionTags             string `ini:"session_tags,omitempty"`
+	TransitiveSessionTags   string `ini:"transitive_session_tags,omitempty"`
+	SourceIdentity          string `ini:"source_identity,omitempty"`
+	CredentialProcess       string `ini:"credential_process,omitempty"`
+	MfaProcess              string `ini:"mfa_process,omitempty"`
+}
+
+// SSOSessionSection is a [sso-session] section of an AWS config file.
+type SSOSessionSection struct {
+	Name                  string `ini:"-"`
+	SSOStartURL           string `ini:"sso_start_url,omitempty"`
+	SSORegion             string `ini:"sso_region,omitempty"`
+	SSORegistrationScopes string `ini:"sso_registration_scopes,omitempty"`
+}
+
+// IsEmpty reports whether the profile has no meaningful configuration.
+func (s ProfileSection) IsEmpty() bool {
+	s.Name = ""
+	return s == ProfileSection{}
+}
+
+// Parser is the interface implemented by all AWS config file parser backends.
+// A value is obtained by calling Load; it retains the file path for subsequent
+// Save and Add calls.
+type Parser interface {
+	// Load reads and parses the AWS config file at path.
+	Load(path string) error
+	// ProfileSections returns all profile sections in declaration order.
+	ProfileSections() []ProfileSection
+	// ProfileSection returns the named profile section and whether it exists.
+	ProfileSection(name string) (ProfileSection, bool)
+	// SSOSessionSection returns the named sso-session section and whether it exists.
+	SSOSessionSection(name string) (SSOSessionSection, bool)
+	// Save writes the current in-memory state back to the file.
+	Save() error
+	// Add creates or replaces the named profile section and saves the file.
+	Add(profile ProfileSection) error
+}

--- a/vault/configparser/custom/custom.go
+++ b/vault/configparser/custom/custom.go
@@ -1,0 +1,428 @@
+// Package custom implements configparser.Parser using a single-pass bufio.Scanner.
+// It is activated by setting AWS_VAULT_USE_CUSTOM_INI_PARSER=true (or 1).
+package custom
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/byteness/aws-vault/v7/vault/configparser"
+)
+
+// Parser implements configparser.Parser with a custom bufio.Scanner backend.
+type Parser struct {
+	path         string
+	rawBytes     []byte
+	sections     map[string]map[string]string
+	sectionOrder []string
+}
+
+// New returns a new custom Parser.
+func New() *Parser { return &Parser{} }
+
+func (p *Parser) Load(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+	p.path = path
+	p.rawBytes = data
+	// Pre-size to reduce rehashing; ~150 bytes per section on average.
+	p.sections = make(map[string]map[string]string, len(data)/150+4)
+	p.sectionOrder = nil
+
+	var current map[string]string
+	var lastKey string // most recently parsed key; tracks active continuation
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Raise the per-line limit to 1 MiB. The default 64 KiB can be exceeded
+	// by long credential_process or web_identity_token_process values.
+	// Use a small initial buffer (4 KiB) so small files don't pay for the
+	// large max-size allocation.
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Continuation line: begins with whitespace and a key is active.
+		// Matching Python configparser / botocore semantics: strip leading
+		// whitespace and append to the current key's value with "\n".
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			if current != nil && lastKey != "" {
+				if cont := strings.TrimSpace(line); cont != "" {
+					current[lastKey] = current[lastKey] + "\n" + cont
+				}
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed[0] == '#' || trimmed[0] == ';' {
+			lastKey = "" // blank/comment terminates any active continuation
+			continue
+		}
+		if trimmed[0] == '[' {
+			current = p.openSection(trimmed)
+			lastKey = ""
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if k, v, ok := splitKeyValue(trimmed); ok {
+			current[k] = v
+			lastKey = k
+		} else {
+			lastKey = "" // malformed line terminates any active continuation
+		}
+	}
+	return scanner.Err()
+}
+
+// openSection parses a section header line (e.g. "[profile foo] # comment"),
+// registers the section if it has not been seen before, and returns its
+// key-value map. Section names are taken verbatim between '[' and the last ']';
+// inner whitespace is preserved to match ini.v1 behaviour.
+func (p *Parser) openSection(line string) map[string]string {
+	closeIdx := strings.LastIndex(line, "]")
+	if closeIdx < 0 {
+		return nil
+	}
+	name := line[1:closeIdx]
+	if m, ok := p.sections[name]; ok {
+		return m // duplicate section — reuse map so keys are merged
+	}
+	m := make(map[string]string, 8)
+	p.sections[name] = m
+	p.sectionOrder = append(p.sectionOrder, name)
+	return m
+}
+
+// splitKeyValue parses a "key=value" or "key: value" line into a lowercased,
+// trimmed key and a processed value. Returns ok=false when no delimiter is
+// found or the key is empty.
+func splitKeyValue(line string) (key, val string, ok bool) {
+	sepIdx := strings.IndexAny(line, "=:")
+	if sepIdx < 0 {
+		return "", "", false
+	}
+	key = strings.ToLower(strings.TrimSpace(line[:sepIdx]))
+	if key == "" {
+		return "", "", false
+	}
+	val = stripInlineComment(strings.TrimSpace(line[sepIdx+1:]))
+	val = stripSurroundingQuotes(val)
+	return key, val, true
+}
+
+// stripInlineComment removes a trailing comment from a value. Only " #" or
+// " ;" (literal space before the marker) trigger stripping — a tab does not —
+// matching ini.v1's SpaceBeforeInlineComment behaviour. When the value begins
+// with a quote, comment markers inside the quoted region are skipped.
+func stripInlineComment(v string) string {
+	searchFrom := 0
+	if len(v) >= 2 && (v[0] == '"' || v[0] == '\'') {
+		if closing := strings.IndexByte(v[1:], v[0]); closing >= 0 {
+			searchFrom = closing + 2
+		}
+	}
+	cutAt := -1
+	for _, marker := range []string{" #", " ;"} {
+		if i := strings.Index(v[searchFrom:], marker); i >= 0 {
+			if pos := searchFrom + i; cutAt < 0 || pos < cutAt {
+				cutAt = pos
+			}
+		}
+	}
+	if cutAt < 0 {
+		return v
+	}
+	return strings.TrimRight(v[:cutAt], " \t")
+}
+
+// stripSurroundingQuotes removes a matching outer '"' or '\” pair, matching
+// ini.v1's PreserveSurroundedQuote=false default.
+func stripSurroundingQuotes(v string) string {
+	if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
+		return v[1 : len(v)-1]
+	}
+	return v
+}
+
+func (p *Parser) ProfileSections() []configparser.ProfileSection {
+	result := []configparser.ProfileSection{}
+	if p.sections == nil {
+		return result
+	}
+	for _, section := range p.sectionOrder {
+		if section == configparser.DefaultSectionName || strings.HasPrefix(section, "profile ") {
+			profile, _ := p.ProfileSection(strings.TrimPrefix(section, "profile "))
+			if section == configparser.DefaultSectionName && profile.IsEmpty() {
+				continue
+			}
+			result = append(result, profile)
+		} else if strings.HasPrefix(section, "sso-session ") || strings.HasPrefix(section, "services ") {
+			continue
+		} else {
+			log.Printf("Unrecognised ini file section: %s", section)
+		}
+	}
+	return result
+}
+
+func (p *Parser) ProfileSection(name string) (configparser.ProfileSection, bool) {
+	profile := configparser.ProfileSection{Name: name}
+	if p.sections == nil {
+		return profile, false
+	}
+	sectionName := "profile " + name
+	if name == configparser.DefaultSectionName {
+		sectionName = configparser.DefaultSectionName
+	}
+	kv, ok := p.sections[sectionName]
+	if !ok {
+		return profile, false
+	}
+	mapToProfileSection(kv, &profile)
+	return profile, true
+}
+
+// mapToProfileSection is the inverse of mapFromProfileSection: it populates a
+// ProfileSection from a key-value map using ini struct tags. Both functions use
+// the same tag-driven dispatch so adding a field to ProfileSection keeps them
+// in sync automatically.
+func mapToProfileSection(kv map[string]string, p *configparser.ProfileSection) {
+	t := reflect.TypeOf(p).Elem()
+	v := reflect.ValueOf(p).Elem()
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("ini")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key := strings.SplitN(tag, ",", 2)[0]
+		fv := v.Field(i)
+		switch fv.Kind() {
+		case reflect.String:
+			fv.SetString(kv[key])
+		case reflect.Uint:
+			if s := kv[key]; s != "" {
+				if n, err := strconv.ParseUint(s, 10, 64); err == nil {
+					fv.SetUint(n)
+				}
+			}
+		}
+	}
+}
+
+// mapToSSOSessionSection populates s from kv using ini struct tags, mirroring
+// mapToProfileSection. Any new field added to SSOSessionSection is handled
+// automatically as long as it carries an ini tag.
+func mapToSSOSessionSection(kv map[string]string, s *configparser.SSOSessionSection) {
+	t := reflect.TypeOf(s).Elem()
+	v := reflect.ValueOf(s).Elem()
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("ini")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key := strings.SplitN(tag, ",", 2)[0]
+		fv := v.Field(i)
+		if fv.Kind() == reflect.String {
+			fv.SetString(kv[key])
+		}
+	}
+}
+
+func (p *Parser) SSOSessionSection(name string) (configparser.SSOSessionSection, bool) {
+	ssoSession := configparser.SSOSessionSection{Name: name}
+	if p.sections == nil {
+		return ssoSession, false
+	}
+	kv, ok := p.sections["sso-session "+name]
+	if !ok {
+		return ssoSession, false
+	}
+	mapToSSOSessionSection(kv, &ssoSession)
+	return ssoSession, true
+}
+
+func (p *Parser) Save() error {
+	// Write to a temp file in the same directory, then rename over the target.
+	// POSIX rename(2) is atomic, so readers always see either the old or new
+	// file — never a partially-written one.
+	dir := filepath.Dir(p.path)
+	tmp, err := os.CreateTemp(dir, ".aws-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file for atomic save: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup: Remove is a no-op after a successful Rename.
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(p.rawBytes); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, p.path); err != nil {
+		return fmt.Errorf("renaming temp file to %s: %w", p.path, err)
+	}
+	return nil
+}
+
+// removeSection excises the named section from raw config bytes. It removes
+// the section header and all lines up to (but not including) the next header.
+// Returns data unchanged if the section is not found. Original line endings
+// (LF or CRLF) are preserved verbatim.
+func removeSection(data []byte, name []byte) []byte {
+	var out bytes.Buffer
+	out.Grow(len(data))
+	skip := false
+	rest := data
+	for len(rest) > 0 {
+		nl := bytes.IndexByte(rest, '\n')
+		var raw []byte
+		if nl < 0 {
+			raw = rest
+			rest = nil
+		} else {
+			raw = rest[:nl+1]
+			rest = rest[nl+1:]
+		}
+		// Strip line ending for analysis only; raw is written as-is.
+		content := bytes.TrimRight(raw, "\r\n")
+		trimmed := bytes.TrimSpace(content)
+		if skip {
+			if len(trimmed) > 0 && trimmed[0] == '[' {
+				skip = false
+			} else {
+				continue
+			}
+		}
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			closeIdx := bytes.LastIndexByte(trimmed, ']')
+			if closeIdx > 0 && bytes.Equal(trimmed[1:closeIdx], name) {
+				skip = true
+				continue
+			}
+		}
+		out.Write(raw)
+	}
+	return out.Bytes()
+}
+
+// mapFromProfileSection builds a key-value map from a ProfileSection using ini struct tags.
+func mapFromProfileSection(prof configparser.ProfileSection) map[string]string {
+	kv := make(map[string]string, 8)
+	t := reflect.TypeOf(prof)
+	v := reflect.ValueOf(prof)
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("ini")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key := strings.SplitN(tag, ",", 2)[0]
+		fv := v.Field(i)
+		switch fv.Kind() {
+		case reflect.String:
+			if s := fv.String(); s != "" {
+				kv[key] = s
+			}
+		case reflect.Uint:
+			if n := fv.Uint(); n > 0 {
+				kv[key] = strconv.FormatUint(n, 10)
+			}
+		}
+	}
+	return kv
+}
+
+func (p *Parser) Add(profile configparser.ProfileSection) error {
+	sectionName := "profile " + profile.Name
+	if profile.Name == configparser.DefaultSectionName {
+		sectionName = configparser.DefaultSectionName
+	}
+
+	// Snapshot in-memory state so we can roll back if Save() fails.
+	prevRawBytes := make([]byte, len(p.rawBytes))
+	copy(prevRawBytes, p.rawBytes)
+	prevSectionOrder := append([]string{}, p.sectionOrder...)
+	prevKV, hadSection := p.sections[sectionName]
+
+	// Remove existing block to prevent unbounded file growth on update.
+	if p.sections != nil {
+		if _, exists := p.sections[sectionName]; exists {
+			p.rawBytes = removeSection(p.rawBytes, []byte(sectionName))
+			// Remove from sectionOrder so it gets re-appended at the tail,
+			// keeping in-memory order consistent with rawBytes position.
+			for i, s := range p.sectionOrder {
+				if s == sectionName {
+					p.sectionOrder = append(p.sectionOrder[:i], p.sectionOrder[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+	kv := mapFromProfileSection(profile)
+	keys := make([]string, 0, len(kv))
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf strings.Builder
+	buf.WriteString("\n[")
+	buf.WriteString(sectionName)
+	buf.WriteString("]\n")
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		val := strings.ReplaceAll(kv[k], "\n", "\n\t")
+		// Quote single-line values that contain inline-comment markers so they
+		// are not truncated by stripInlineComment on the next Load().
+		if needsQuoting(val) {
+			buf.WriteByte('"')
+			buf.WriteString(val)
+			buf.WriteByte('"')
+		} else {
+			buf.WriteString(val)
+		}
+		buf.WriteByte('\n')
+	}
+	p.rawBytes = append(p.rawBytes, []byte(buf.String())...)
+	if p.sections == nil {
+		p.sections = make(map[string]map[string]string)
+	}
+	p.sectionOrder = append(p.sectionOrder, sectionName)
+	p.sections[sectionName] = kv
+
+	if err := p.Save(); err != nil {
+		// Roll back all in-memory mutations so the caller sees a consistent state.
+		p.rawBytes = prevRawBytes
+		p.sectionOrder = prevSectionOrder
+		if hadSection {
+			p.sections[sectionName] = prevKV
+		} else {
+			delete(p.sections, sectionName)
+		}
+		return err
+	}
+	return nil
+}
+
+// needsQuoting reports whether v must be wrapped in double quotes when
+// serialized to file. Only single-line values are quoted; continuation lines
+// in multi-line values are indented and are not subject to inline-comment
+// stripping on Load().
+func needsQuoting(v string) bool {
+	if strings.ContainsRune(v, '\n') {
+		return false
+	}
+	return (strings.Contains(v, " #") || strings.Contains(v, " ;")) &&
+		!strings.Contains(v, `"`)
+}

--- a/vault/configparser/custom/custom_test.go
+++ b/vault/configparser/custom/custom_test.go
@@ -1,0 +1,578 @@
+package custom
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/byteness/aws-vault/v7/vault/configparser"
+)
+
+// writeConfig writes content to a temp file and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+	return path
+}
+
+// loadConfig is a shorthand for creating a Parser and calling Load.
+func loadConfig(t *testing.T, content string) *Parser {
+	t.Helper()
+	p := New()
+	if err := p.Load(writeConfig(t, content)); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return p
+}
+
+// --- splitKeyValue ---
+
+func TestSplitKeyValueEquals(t *testing.T) {
+	k, v, ok := splitKeyValue("region=us-east-1")
+	if !ok || k != "region" || v != "us-east-1" {
+		t.Fatalf("got k=%q v=%q ok=%v", k, v, ok)
+	}
+}
+
+func TestSplitKeyValueColon(t *testing.T) {
+	k, v, ok := splitKeyValue("region: us-east-1")
+	if !ok || k != "region" || v != "us-east-1" {
+		t.Fatalf("got k=%q v=%q ok=%v", k, v, ok)
+	}
+}
+
+func TestSplitKeyValueLowercasesKey(t *testing.T) {
+	k, _, ok := splitKeyValue("Region=us-east-1")
+	if !ok || k != "region" {
+		t.Fatalf("got k=%q ok=%v", k, ok)
+	}
+}
+
+func TestSplitKeyValueTrimsKeyWhitespace(t *testing.T) {
+	k, v, ok := splitKeyValue("  region  =  us-east-1  ")
+	if !ok || k != "region" || v != "us-east-1" {
+		t.Fatalf("got k=%q v=%q ok=%v", k, v, ok)
+	}
+}
+
+func TestSplitKeyValueNoDelimiter(t *testing.T) {
+	_, _, ok := splitKeyValue("just-a-word")
+	if ok {
+		t.Fatal("expected ok=false when no delimiter")
+	}
+}
+
+func TestSplitKeyValueEmptyKey(t *testing.T) {
+	_, _, ok := splitKeyValue("=value")
+	if ok {
+		t.Fatal("expected ok=false for empty key")
+	}
+}
+
+func TestSplitKeyValueEmptyValue(t *testing.T) {
+	k, v, ok := splitKeyValue("key=")
+	if !ok || k != "key" || v != "" {
+		t.Fatalf("got k=%q v=%q ok=%v", k, v, ok)
+	}
+}
+
+// --- stripInlineComment ---
+
+func TestStripInlineCommentNoComment(t *testing.T) {
+	if got := stripInlineComment("us-east-1"); got != "us-east-1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripInlineCommentHash(t *testing.T) {
+	if got := stripInlineComment("us-east-1 # comment"); got != "us-east-1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripInlineCommentSemicolon(t *testing.T) {
+	if got := stripInlineComment("us-east-1 ; comment"); got != "us-east-1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripInlineCommentTabBeforeHashNotStripped(t *testing.T) {
+	v := "us-east-1\t#comment"
+	if got := stripInlineComment(v); got != v {
+		t.Fatalf("got %q, want %q", got, v)
+	}
+}
+
+func TestStripInlineCommentHashInsideDoubleQuotesPreserved(t *testing.T) {
+	if got := stripInlineComment(`"value#with#hashes"`); got != `"value#with#hashes"` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripInlineCommentHashAfterClosingQuote(t *testing.T) {
+	if got := stripInlineComment(`"value" # comment`); got != `"value"` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripInlineCommentPicksEarliest(t *testing.T) {
+	if got := stripInlineComment("val ; first # second"); got != "val" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// --- stripSurroundingQuotes ---
+
+func TestStripSurroundingQuotesDouble(t *testing.T) {
+	if got := stripSurroundingQuotes(`"hello"`); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripSurroundingQuotesSingle(t *testing.T) {
+	if got := stripSurroundingQuotes("'hello'"); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripSurroundingQuotesMismatch(t *testing.T) {
+	v := `"hello'`
+	if got := stripSurroundingQuotes(v); got != v {
+		t.Fatalf("got %q, want %q (mismatched quotes should not be stripped)", got, v)
+	}
+}
+
+func TestStripSurroundingQuotesNoQuotes(t *testing.T) {
+	if got := stripSurroundingQuotes("hello"); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripSurroundingQuotesTooShort(t *testing.T) {
+	if got := stripSurroundingQuotes(`"`); got != `"` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// --- removeSection ---
+
+func TestRemoveSectionMiddle(t *testing.T) {
+	input := []byte("[default]\nregion=us-east-1\n\n[profile foo]\nrole_arn=arn:aws:iam::123:role/foo\n\n[profile bar]\nregion=eu-west-1\n")
+	got := removeSection(input, []byte("profile foo"))
+	want := []byte("[default]\nregion=us-east-1\n\n[profile bar]\nregion=eu-west-1\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRemoveSectionLast(t *testing.T) {
+	input := []byte("[default]\nregion=us-east-1\n\n[profile foo]\nrole_arn=arn:aws:iam::123:role/foo\n")
+	got := removeSection(input, []byte("profile foo"))
+	want := []byte("[default]\nregion=us-east-1\n\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRemoveSectionNotFound(t *testing.T) {
+	input := []byte("[default]\nregion=us-east-1\n")
+	got := removeSection(input, []byte("profile nonexistent"))
+	if !bytes.Equal(got, input) {
+		t.Fatalf("got:\n%s\nwant:\n%s (unchanged)", got, input)
+	}
+}
+
+func TestRemoveSectionPreservesIndentedSubProperties(t *testing.T) {
+	input := []byte("[profile keep]\nregion=us-east-1\n\n[profile remove]\nrole_arn=arn:aws:iam::123:role/r\n  services=s3\n\n[profile keep2]\nregion=eu-west-1\n")
+	got := removeSection(input, []byte("profile remove"))
+	want := []byte("[profile keep]\nregion=us-east-1\n\n[profile keep2]\nregion=eu-west-1\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRemoveSectionPreservesCRLF(t *testing.T) {
+	input := []byte("[default]\r\nregion=us-east-1\r\n\r\n[profile foo]\r\nrole_arn=arn:aws:iam::123:role/foo\r\n\r\n[profile bar]\r\nregion=eu-west-1\r\n")
+	got := removeSection(input, []byte("profile foo"))
+	want := []byte("[default]\r\nregion=us-east-1\r\n\r\n[profile bar]\r\nregion=eu-west-1\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("CRLF line endings not preserved.\ngot (hex):\n%x\nwant (hex):\n%x", got, want)
+	}
+}
+
+// --- mapFromProfileSection ---
+
+func TestMapFromProfileSectionOmitsEmptyFields(t *testing.T) {
+	p := configparser.ProfileSection{Name: "myprofile", Region: "us-east-1"}
+	kv := mapFromProfileSection(p)
+	if _, ok := kv["mfa_serial"]; ok {
+		t.Fatal("empty fields should be omitted from map")
+	}
+	if kv["region"] != "us-east-1" {
+		t.Fatalf("expected region=us-east-1, got %q", kv["region"])
+	}
+}
+
+func TestMapFromProfileSectionDurationSeconds(t *testing.T) {
+	p := configparser.ProfileSection{Name: "p", DurationSeconds: 3600}
+	kv := mapFromProfileSection(p)
+	if kv["duration_seconds"] != "3600" {
+		t.Fatalf("expected duration_seconds=3600, got %q", kv["duration_seconds"])
+	}
+}
+
+func TestMapFromProfileSectionZeroDurationOmitted(t *testing.T) {
+	p := configparser.ProfileSection{Name: "p", DurationSeconds: 0}
+	kv := mapFromProfileSection(p)
+	if _, ok := kv["duration_seconds"]; ok {
+		t.Fatal("zero DurationSeconds should be omitted")
+	}
+}
+
+// --- sectionOrder consistency after overwrite ---
+
+func TestSectionOrderAfterOverwrite(t *testing.T) {
+	// Start with two profiles.
+	parser := &Parser{}
+	parser.sections = map[string]map[string]string{
+		"profile a": {"region": "us-east-1"},
+		"profile b": {"region": "eu-west-1"},
+	}
+	parser.sectionOrder = []string{"profile a", "profile b"}
+	parser.rawBytes = []byte("[profile a]\nregion=us-east-1\n\n[profile b]\nregion=eu-west-1\n")
+	parser.path = t.TempDir() + "/config"
+
+	// Overwrite profile a.
+	if err := parser.Add(configparser.ProfileSection{Name: "a", Region: "ap-southeast-1"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// profile a should now be last in sectionOrder (moved to tail like rawBytes).
+	order := parser.sectionOrder
+	if len(order) != 2 {
+		t.Fatalf("expected 2 sections, got %v", order)
+	}
+	if order[0] != "profile b" || order[1] != "profile a" {
+		t.Fatalf("expected [profile b, profile a], got %v", order)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-line continuation value parsing (botocore compatibility)
+// ---------------------------------------------------------------------------
+//
+// Python configparser (used by botocore) treats any line that begins with
+// whitespace as a continuation of the previous key's value. The continuation
+// line has its leading whitespace stripped and is appended to the current
+// value with a "\n" separator. aws-vault's custom parser must match this
+// so that multi-line credential_process / web_identity_token_process values
+// round-trip correctly.
+
+// TestContinuationSpaceIndent verifies that a space-indented continuation
+// line is appended to the previous key's value.
+func TestContinuationSpaceIndent(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec prod\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	want := "/usr/bin/aws-vault\nexec prod"
+	if prof.CredentialProcess != want {
+		t.Fatalf("got %q, want %q", prof.CredentialProcess, want)
+	}
+}
+
+// TestContinuationTabIndent verifies that a tab-indented continuation line
+// is treated identically to a space-indented one.
+func TestContinuationTabIndent(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n\texec prod\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	want := "/usr/bin/aws-vault\nexec prod"
+	if prof.CredentialProcess != want {
+		t.Fatalf("got %q, want %q", prof.CredentialProcess, want)
+	}
+}
+
+// TestContinuationMultipleLines verifies that several continuation lines are
+// all appended, each separated by "\n".
+func TestContinuationMultipleLines(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec prod\n  --duration=1h\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	want := "/usr/bin/aws-vault\nexec prod\n--duration=1h"
+	if prof.CredentialProcess != want {
+		t.Fatalf("got %q, want %q", prof.CredentialProcess, want)
+	}
+}
+
+// TestContinuationStopsAtBlankLine verifies that a blank line terminates the
+// continuation (matching Python configparser semantics).
+func TestContinuationStopsAtBlankLine(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n\nexec prod\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	// blank line resets continuation; "exec prod" (no indent) is not a valid
+	// key=value line, so it is ignored, not appended.
+	want := "/usr/bin/aws-vault"
+	if prof.CredentialProcess != want {
+		t.Fatalf("got %q, want %q", prof.CredentialProcess, want)
+	}
+}
+
+// TestContinuationStopsAtNextSection verifies that a section header terminates
+// the continuation and the following key belongs to the new section.
+func TestContinuationStopsAtNextSection(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec foo\n\n[profile bar]\nregion = eu-west-1\n")
+	foo, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	if foo.CredentialProcess != "/usr/bin/aws-vault\nexec foo" {
+		t.Fatalf("foo.credential_process = %q", foo.CredentialProcess)
+	}
+	bar, ok := p.ProfileSection("bar")
+	if !ok {
+		t.Fatal("profile bar not found")
+	}
+	if bar.Region != "eu-west-1" {
+		t.Fatalf("bar.region = %q", bar.Region)
+	}
+	// continuation must not bleed into bar
+	if bar.CredentialProcess != "" {
+		t.Fatalf("bar.credential_process should be empty, got %q", bar.CredentialProcess)
+	}
+}
+
+// TestContinuationDoesNotAffectOtherKeys verifies that only the immediately
+// preceding key is extended; subsequent keys in the same section are
+// unaffected.
+func TestContinuationDoesNotAffectOtherKeys(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec foo\nregion = us-east-1\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	if prof.CredentialProcess != "/usr/bin/aws-vault\nexec foo" {
+		t.Fatalf("credential_process = %q", prof.CredentialProcess)
+	}
+	if prof.Region != "us-east-1" {
+		t.Fatalf("region = %q", prof.Region)
+	}
+}
+
+// TestContinuationSubsectionPattern verifies that the botocore subsection
+// pattern (key on its own, value entirely in indented lines) produces a raw
+// string starting with "\n", matching what Python configparser returns before
+// botocore's _parse_nested step.
+func TestContinuationSubsectionPattern(t *testing.T) {
+	// aws-vault does not use nested service config, but the raw value must
+	// survive in sections so Save() round-trips are stable.
+	p := loadConfig(t, "[profile foo]\nregion = us-east-1\ns3 =\n  endpoint_url = https://s3.example.com\n  addressing_style = path\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	if prof.Region != "us-east-1" {
+		t.Fatalf("region = %q", prof.Region)
+	}
+	// "s3" is not a ProfileSection field; verify it is stored in sections map
+	// as the raw continuation string starting with "\n".
+	raw := p.sections["profile foo"]["s3"]
+	if len(raw) == 0 || raw[0] != '\n' {
+		t.Fatalf("s3 raw value should start with newline, got %q", raw)
+	}
+	if raw != "\nendpoint_url = https://s3.example.com\naddressing_style = path" {
+		t.Fatalf("s3 raw value = %q", raw)
+	}
+}
+
+// TestContinuationPreservedInRawBytes verifies that rawBytes is unchanged by
+// the logical parsing of continuation lines — the original file content is
+// preserved for lossless Save().
+func TestContinuationPreservedInRawBytes(t *testing.T) {
+	content := "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec prod\n"
+	p := loadConfig(t, content)
+	if !bytes.Equal(p.rawBytes, []byte(content)) {
+		t.Fatalf("rawBytes mutated during load;\ngot:  %q\nwant: %q", p.rawBytes, content)
+	}
+}
+
+// TestContinuationNotExtendedPastMalformedLine verifies that a non-indented
+// line that fails key=value parsing (no delimiter) resets the active
+// continuation, so the indented line that follows does not spuriously extend
+// the previous key.
+func TestContinuationNotExtendedPastMalformedLine(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\ncredential_process = /usr/bin/aws-vault\nJUNK\n  this-must-not-append\n")
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	if prof.CredentialProcess != "/usr/bin/aws-vault" {
+		t.Fatalf("got %q, want %q", prof.CredentialProcess, "/usr/bin/aws-vault")
+	}
+}
+
+// --- B2: Add() must quote values containing inline-comment markers ---
+
+// TestAddRoundTripValueWithCommentMarker verifies that a value containing
+// " # " survives an Add() → re-Load() round-trip intact.  Without quoting,
+// stripInlineComment would truncate the value on the next Load().
+func TestAddRoundTripValueWithCommentMarker(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\nregion=us-east-1\n")
+
+	credProcess := "/usr/bin/wrapper --flag1 # not-a-comment"
+	if err := p.Add(configparser.ProfileSection{
+		Name:              "foo",
+		Region:            "us-east-1",
+		CredentialProcess: credProcess,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	p2 := New()
+	if err := p2.Load(p.path); err != nil {
+		t.Fatalf("re-Load: %v", err)
+	}
+	prof, ok := p2.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found after round-trip")
+	}
+	if prof.CredentialProcess != credProcess {
+		t.Fatalf("credential_process = %q, want %q", prof.CredentialProcess, credProcess)
+	}
+}
+
+// TestAddRoundTripValueWithSemicolonCommentMarker verifies the same for " ; ".
+func TestAddRoundTripValueWithSemicolonCommentMarker(t *testing.T) {
+	p := loadConfig(t, "[profile foo]\nregion=us-east-1\n")
+
+	credProcess := "/usr/bin/wrapper --opt=val ; side-note"
+	if err := p.Add(configparser.ProfileSection{
+		Name:              "foo",
+		Region:            "us-east-1",
+		CredentialProcess: credProcess,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	p2 := New()
+	if err := p2.Load(p.path); err != nil {
+		t.Fatalf("re-Load: %v", err)
+	}
+	prof, ok := p2.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found after round-trip")
+	}
+	if prof.CredentialProcess != credProcess {
+		t.Fatalf("credential_process = %q, want %q", prof.CredentialProcess, credProcess)
+	}
+}
+
+// --- B3: Add() must roll back in-memory state when Save() fails ---
+
+// TestAddRollsBackOnSaveFailure verifies that when Save() fails (because the
+// path is in a non-existent directory), Add() leaves rawBytes, sectionOrder,
+// and sections exactly as they were before the call.
+func TestAddRollsBackOnSaveFailure(t *testing.T) {
+	p := &Parser{
+		path:     "/nonexistent-dir-for-test/config",
+		rawBytes: []byte("[profile foo]\nregion=us-east-1\n"),
+		sections: map[string]map[string]string{
+			"profile foo": {"region": "us-east-1"},
+		},
+		sectionOrder: []string{"profile foo"},
+	}
+
+	origBytes := make([]byte, len(p.rawBytes))
+	copy(origBytes, p.rawBytes)
+	origOrder := append([]string{}, p.sectionOrder...)
+
+	err := p.Add(configparser.ProfileSection{Name: "bar", Region: "eu-west-1"})
+	if err == nil {
+		t.Fatal("expected Add() to fail with non-existent path")
+	}
+
+	if !bytes.Equal(p.rawBytes, origBytes) {
+		t.Fatalf("rawBytes not rolled back after failed Save();\ngot:  %q\nwant: %q", p.rawBytes, origBytes)
+	}
+	if len(p.sectionOrder) != len(origOrder) {
+		t.Fatalf("sectionOrder not rolled back: %v", p.sectionOrder)
+	}
+	if _, exists := p.sections["profile bar"]; exists {
+		t.Fatal("sections[\"profile bar\"] still present after failed Save()")
+	}
+}
+
+// --- A3: SSOSessionSection must be reflection-driven ---
+
+// TestSSOSessionSectionAllFieldsRoundTrip verifies that all ini-tagged fields
+// of SSOSessionSection are populated correctly.  This test passes before and
+// after the A3 refactor; it guards against a regression when new fields are
+// added to SSOSessionSection — hardcoded assignments would silently miss them.
+func TestSSOSessionSectionAllFieldsRoundTrip(t *testing.T) {
+	p := loadConfig(t, "[sso-session dev]\nsso_start_url=https://my-sso.awsapps.com/start\nsso_region=us-east-1\nsso_registration_scopes=sso:account:access\n")
+	s, ok := p.SSOSessionSection("dev")
+	if !ok {
+		t.Fatal("sso-session dev not found")
+	}
+	if s.SSOStartURL != "https://my-sso.awsapps.com/start" {
+		t.Fatalf("SSOStartURL = %q", s.SSOStartURL)
+	}
+	if s.SSORegion != "us-east-1" {
+		t.Fatalf("SSORegion = %q", s.SSORegion)
+	}
+	if s.SSORegistrationScopes != "sso:account:access" {
+		t.Fatalf("SSORegistrationScopes = %q", s.SSORegistrationScopes)
+	}
+}
+
+// TestAddRoundTripMultilineValue verifies that a profile containing a
+// multi-line credential_process survives an Add() → re-Load() round-trip
+// with the full value intact. This guards against Add() writing continuation
+// lines without indentation, which would cause the second line to be silently
+// dropped on the next Load().
+func TestAddRoundTripMultilineValue(t *testing.T) {
+	content := "[profile foo]\ncredential_process = /usr/bin/aws-vault\n  exec prod\n"
+	p := loadConfig(t, content)
+
+	prof, ok := p.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found")
+	}
+	wantCP := "/usr/bin/aws-vault\nexec prod"
+	if prof.CredentialProcess != wantCP {
+		t.Fatalf("initial load: credential_process = %q, want %q", prof.CredentialProcess, wantCP)
+	}
+
+	// Update an unrelated field and re-write the profile via Add().
+	prof.Region = "us-east-1"
+	if err := p.Add(prof); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Re-load from the file Add() wrote and verify the multi-line value survived.
+	p2 := New()
+	if err := p2.Load(p.path); err != nil {
+		t.Fatalf("re-Load: %v", err)
+	}
+	prof2, ok := p2.ProfileSection("foo")
+	if !ok {
+		t.Fatal("profile foo not found after round-trip")
+	}
+	if prof2.CredentialProcess != wantCP {
+		t.Fatalf("after round-trip: credential_process = %q, want %q", prof2.CredentialProcess, wantCP)
+	}
+	if prof2.Region != "us-east-1" {
+		t.Fatalf("after round-trip: region = %q", prof2.Region)
+	}
+}

--- a/vault/configparser/iniv1/iniv1.go
+++ b/vault/configparser/iniv1/iniv1.go
@@ -1,0 +1,111 @@
+// Package iniv1 implements configparser.Parser using gopkg.in/ini.v1.
+package iniv1
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/byteness/aws-vault/v7/vault/configparser"
+	ini "gopkg.in/ini.v1"
+)
+
+// Parser implements configparser.Parser using gopkg.in/ini.v1.
+type Parser struct {
+	path    string
+	iniFile *ini.File
+}
+
+// prettyFormatOnce guards the single write to ini.PrettyFormat, which is a
+// package-level variable in gopkg.in/ini.v1. Concurrent Load() calls would
+// race on it without this guard.
+var prettyFormatOnce sync.Once
+
+// New returns a new ini.v1-backed Parser.
+func New() *Parser {
+	prettyFormatOnce.Do(func() { ini.PrettyFormat = false })
+	return &Parser{}
+}
+
+func (p *Parser) Load(path string) error {
+	p.path = path
+	f, err := ini.LoadSources(ini.LoadOptions{
+		AllowNestedValues:        true,
+		InsensitiveSections:      false,
+		InsensitiveKeys:          true,
+		SpaceBeforeInlineComment: true,
+	}, path)
+	if err != nil {
+		return err
+	}
+	p.iniFile = f
+	return nil
+}
+
+func (p *Parser) ProfileSections() []configparser.ProfileSection {
+	result := []configparser.ProfileSection{}
+	for _, section := range p.iniFile.SectionStrings() {
+		if section == configparser.DefaultSectionName || strings.HasPrefix(section, "profile ") {
+			profile, _ := p.ProfileSection(strings.TrimPrefix(section, "profile "))
+			if section == configparser.DefaultSectionName && profile.IsEmpty() {
+				continue
+			}
+			result = append(result, profile)
+		} else if strings.HasPrefix(section, "sso-session ") || strings.HasPrefix(section, "services ") {
+			continue
+		} else {
+			log.Printf("Unrecognised ini file section: %s", section)
+		}
+	}
+	return result
+}
+
+func (p *Parser) ProfileSection(name string) (configparser.ProfileSection, bool) {
+	profile := configparser.ProfileSection{Name: name}
+	sectionName := "profile " + name
+	if name == configparser.DefaultSectionName {
+		sectionName = configparser.DefaultSectionName
+	}
+	section, err := p.iniFile.GetSection(sectionName)
+	if err != nil {
+		return profile, false
+	}
+	if err = section.MapTo(&profile); err != nil {
+		log.Printf("Failed to map ini section %q to profile: %v", sectionName, err)
+		return profile, false
+	}
+	return profile, true
+}
+
+func (p *Parser) SSOSessionSection(name string) (configparser.SSOSessionSection, bool) {
+	ssoSession := configparser.SSOSessionSection{Name: name}
+	section, err := p.iniFile.GetSection("sso-session " + name)
+	if err != nil {
+		return ssoSession, false
+	}
+	if err = section.MapTo(&ssoSession); err != nil {
+		log.Printf("Failed to map ini section %q to sso-session: %v", "sso-session "+name, err)
+		return ssoSession, false
+	}
+	return ssoSession, true
+}
+
+func (p *Parser) Save() error {
+	return p.iniFile.SaveTo(p.path)
+}
+
+func (p *Parser) Add(profile configparser.ProfileSection) error {
+	sectionName := "profile " + profile.Name
+	if profile.Name == configparser.DefaultSectionName {
+		sectionName = configparser.DefaultSectionName
+	}
+	section, err := p.iniFile.NewSection(sectionName)
+	if err != nil {
+		return fmt.Errorf("creating section %q: %w", profile.Name, err)
+	}
+	if err = section.ReflectFrom(&profile); err != nil {
+		return fmt.Errorf("mapping profile to ini section: %w", err)
+	}
+	return p.Save()
+}

--- a/vault/configparser/iniv1/iniv1_test.go
+++ b/vault/configparser/iniv1/iniv1_test.go
@@ -1,0 +1,36 @@
+package iniv1
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+	return path
+}
+
+// TestLoadConcurrentNoRace verifies that concurrent Load() calls on distinct
+// Parser instances do not race on shared state.  Run with -race to detect the
+// data race on ini.PrettyFormat that exists before the sync.Once fix.
+func TestLoadConcurrentNoRace(t *testing.T) {
+	path := writeConfig(t, "[profile foo]\nregion=us-east-1\n")
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p := New()
+			if err := p.Load(path); err != nil {
+				t.Errorf("Load: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Introduces an opt-in custom AWS config file parser as a (drastically) faster alternative to `gopkg.in/ini.v1`, controlled by the environment variable `AWS_VAULT_USE_CUSTOM_INI_PARSER=true`. 

New parser improves the performance of loading all config files, from 10% on small ones to above 2 orders of magnitude for large ones.  Also reduces CPU and RSS overhead drastically in most cases. Hoping this can be the default parser in the future. 🤞 

75%+ of the diff is tests to ensure as close of compatibility as possible. 

Note for reviewers: This PR was made with help of AI tooling

### Motivation

The motivation is performance at scale: users with large AWS organizations can have config files with tens of thousands of profiles. At 100k profiles, the ini.v1 parser takes **~29 seconds** to load; the custom parser takes **~85 ms** — **_a 340× speedup_**!.

Fixes: https://github.com/ByteNess/aws-vault/issues/396

### Architecture

A `configparser.Parser` interface abstracts the two backends:

```
vault/configparser/
  configparser.go       — Parser interface, ProfileSection, SSOSessionSection types
  iniv1/iniv1.go        — existing ini.v1 backend (unchanged behaviour)
  custom/custom.go      — new single-pass bufio.Scanner backend
```

`vault.ConfigFile` holds a `configparser.Parser` and delegates all reads and writes to it. `vault.LoadConfig` selects the backend from the env var at startup. Callers are unaffected — the change is transparent behind the existing API.

### Custom parser highlights

- **Single-pass bufio.Scanner** — one allocation per section map entry, no intermediate AST
- **Botocore-compatible multi-line continuation** — indented lines are appended to the previous key's value, matching Python `configparser` semantics (needed for multi-line `credential_process` and `web_identity_token_process` values)
- **Atomic saves** — writes to a temp file and renames, so a crash mid-write never corrupts the config file
- **Rollback on save failure** — `Add()` restores in-memory state if `Save()` fails
- **Inline-comment quoting** — values containing ` # ` or ` ; ` are quoted on write so they survive a re-read
- **CRLF-safe section removal** — byte-level iteration preserves original line endings

### Benchmarks

Apple M3 Max · darwin/arm64 · `go test -bench=. -benchmem -count=3 -benchtime=3s`

| Benchmark | iniv1 | custom | Speedup |
|---|---|---|---|
| ParseSmall (6 profiles) | 22.3 µs · 121 allocs · 12.5 KiB | 19.4 µs · 40 allocs · 7.5 KiB | 1.1× faster · **3.0× fewer allocs** |
| ParseLarge (200k profiles) | 29.0 s · 4.4M allocs · 349 MiB | 85.7 ms · 1.2M allocs · 136 MiB | **340× faster** · 3.7× fewer allocs · 2.6× less memory |
| ProfileSectionLookup | 7.5 µs · 104 allocs · 4.7 KiB | 2.0 µs · 22 allocs · 0.7 KiB | **3.8× faster** · 4.7× fewer allocs |
| ProfileSections (list all) | 31.3 µs · 427 allocs · 21.9 KiB | 8.4 µs · 91 allocs · 5.4 KiB | **3.7× faster** · 4.7× fewer allocs |

### Testing

- Existing `vault/config_test.go` tests run against both backends via a `testBothParsers` helper — no behaviour change between backends
- `vault/configparser/custom/custom_test.go` — 30+ unit tests covering: section parsing, inline comment stripping, CRLF handling, multi-line continuation (8 cases), `Add()` round-trips, rollback on save failure, and value quoting
- `vault/configparser/iniv1/iniv1_test.go` — concurrent `Load()` test (run with `-race`) guarding the `sync.Once` fix for `ini.PrettyFormat`
- `vault/configparser/bench_test.go` — direct side-by-side benchmarks of both backends

### Activation

```bash
AWS_VAULT_USE_CUSTOM_INI_PARSER=true aws-vault exec my-profile -- aws s3 ls
```

The default remains the ini.v1 backend. The custom parser is opt-in until it has broader real-world validation.