### PR TITLE
refactor(config): consolidate SSO start URL precedence into a shared helper

### DIFF
--- a/cli/clear.go
+++ b/cli/clear.go
@@ -62,12 +62,7 @@ func ClearCommand(input ClearCommandInput, awsConfigFile *vault.ConfigFile, keyr
 		}
 
 		if profileSection, ok := awsConfigFile.ProfileSection(input.ProfileName); ok {
-			startURL := profileSection.SSOStartURL
-			if profileSection.SSOSession != "" {
-				if s, ok := awsConfigFile.SSOSessionSection(profileSection.SSOSession); ok && s.SSOStartURL != "" {
-					startURL = s.SSOStartURL
-				}
-			}
+			startURL := awsConfigFile.ResolvedSSOStartURL(profileSection)
 			if startURL != "" {
 				if exists, _ := oidcTokens.Has(startURL); exists {
 					err = oidcTokens.Remove(startURL)

--- a/cli/list.go
+++ b/cli/list.go
@@ -201,13 +201,9 @@ func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyrin
 
 		var sessionLabels []string
 
-		// check oidc keyring
-		startURL := profileSection.SSOStartURL
-		if profileSection.SSOSession != "" {
-			if u := ssoSessionStartURLs[profileSection.SSOSession]; u != "" {
-				startURL = u
-			}
-		}
+		// check oidc keyring. Resolve the start URL via the shared precedence
+		// rule, using the prefetched sso-session map to stay O(1) per profile.
+		startURL := vault.ResolveSSOStartURL(profileSection.SSOStartURL, ssoSessionStartURLs[profileSection.SSOSession])
 		if startURL != "" {
 			if label, ok := oidcTokenLabels[startURL]; ok {
 				sessionLabels = append(sessionLabels, label)

--- a/vault/config.go
+++ b/vault/config.go
@@ -238,6 +238,35 @@ func (c *ConfigFile) SSOSessionStartURLs() map[string]string {
 	return result
 }
 
+// ResolveSSOStartURL applies the canonical precedence for a profile's SSO start
+// URL: the referenced [sso-session] section's sso_start_url wins, falling back
+// to the profile's inline sso_start_url only when the session url is empty.
+//
+// This mirrors how ConfigLoader.populateFromConfigFile resolves SSOStartURL and
+// is the single source of truth for that rule. Callers that have already
+// resolved the [sso-session] url (e.g. from a prefetched map) pass it directly;
+// see ConfigFile.ResolvedSSOStartURL for the section-lookup convenience.
+func ResolveSSOStartURL(inlineStartURL, ssoSessionStartURL string) string {
+	if ssoSessionStartURL != "" {
+		return ssoSessionStartURL
+	}
+	return inlineStartURL
+}
+
+// ResolvedSSOStartURL returns the SSO start URL for a profile section using the
+// precedence defined by ResolveSSOStartURL, looking up the referenced
+// [sso-session] section as needed. Returns "" when the profile has neither an
+// inline sso_start_url nor a resolvable sso-session url.
+func (c *ConfigFile) ResolvedSSOStartURL(p ProfileSection) string {
+	var ssoSessionStartURL string
+	if p.SSOSession != "" {
+		if s, ok := c.SSOSessionSection(p.SSOSession); ok {
+			ssoSessionStartURL = s.SSOStartURL
+		}
+	}
+	return ResolveSSOStartURL(p.SSOStartURL, ssoSessionStartURL)
+}
+
 // SSOSessionSection returns the [sso-session] section with the matching name. If there isn't any,
 // an empty sso-session with the provided name is returned, along with false.
 func (c *ConfigFile) SSOSessionSection(name string) (SSOSessionSection, bool) {

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -623,3 +623,78 @@ source_profile = interim
 		t.Fatalf("Expected transitive_session_tags to be empty, got %+v", baseConfig.TransitiveSessionTags)
 	}
 }
+
+// TestResolveSSOStartURL covers the pure precedence rule shared by list, clear
+// and the config loader: the [sso-session] url wins, with the inline
+// sso_start_url as fallback only when the session url is empty.
+func TestResolveSSOStartURL(t *testing.T) {
+	const inline = "https://inline.awsapps.com/start"
+	const session = "https://session.awsapps.com/start"
+
+	cases := []struct {
+		name          string
+		inlineURL     string
+		ssoSessionURL string
+		want          string
+	}{
+		{"session wins over inline", inline, session, session},
+		{"inline used when no session url", inline, "", inline},
+		{"session used when no inline", "", session, session},
+		{"empty when neither set", "", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vault.ResolveSSOStartURL(tc.inlineURL, tc.ssoSessionURL); got != tc.want {
+				t.Errorf("ResolveSSOStartURL(%q, %q) = %q, want %q", tc.inlineURL, tc.ssoSessionURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfigFileResolvedSSOStartURL verifies the section-lookup convenience
+// resolves the [sso-session] url for modern profiles, the inline url for legacy
+// profiles, and gives the session url precedence when a profile sets both.
+func TestConfigFileResolvedSSOStartURL(t *testing.T) {
+	f := newConfigFile(t, []byte(`[sso-session my-sso]
+sso_start_url = https://session.awsapps.com/start
+sso_region = us-east-1
+
+[profile modern]
+sso_session = my-sso
+sso_account_id = 111122223333
+
+[profile legacy]
+sso_start_url = https://inline.awsapps.com/start
+sso_account_id = 222233334444
+
+[profile both]
+sso_session = my-sso
+sso_start_url = https://inline.awsapps.com/start
+sso_account_id = 333344445555
+
+[profile none]
+region = us-east-1
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]string{
+		"modern": "https://session.awsapps.com/start",
+		"legacy": "https://inline.awsapps.com/start",
+		"both":   "https://session.awsapps.com/start",
+		"none":   "",
+	}
+	for profileName, want := range cases {
+		t.Run(profileName, func(t *testing.T) {
+			ps, _ := configFile.ProfileSection(profileName)
+			if got := configFile.ResolvedSSOStartURL(ps); got != want {
+				t.Errorf("ResolvedSSOStartURL(%q) = %q, want %q", profileName, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The precedence rule "the [sso-session] url wins, inline sso_start_url is the fallback" was duplicated in three places: ConfigLoader.populateFromConfigFile, ListCommand, and ClearCommand. The list/clear copies had previously drifted from the loader, which was the root cause of the OIDC-token-not-shown/not-cleared bug for profiles that set both an inline url and an sso_session.

Extract the rule into vault.ResolveSSOStartURL (pure, single definition) plus a ConfigFile.ResolvedSSOStartURL convenience that performs the [sso-session] lookup. ClearCommand now calls the convenience method; ListCommand calls the pure rule with its prefetched sso-session map, preserving the O(1)-per-profile lookup from the earlier perf work. Behavior is unchanged for all configs.

Adds `TestResolveSSOStartURL` and `TestConfigFileResolvedSSOStartURL` covering the rule and the section-lookup variant (modern, legacy, both-set, neither).

Related to #400 #402