### PR TITLE
feat: add Proton Pass backend

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -290,6 +290,10 @@ To configure the default flag values of `aws-vault` and its subcommands:
 * `AWS_VAULT_OP_CONNECT_TOKEN`: 1Password Connect server access token
 * `AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN`: 1Password service account token
 * `AWS_VAULT_OP_DESKTOP_ACCOUNT_ID`: 1Password Desktop App account name or account UUID (see the flag `--op-desktop-account-id`)
+* `AWS_VAULT_PROTON_PASS_SHARE_ID`: Share ID of the Proton Pass vault to use (see the flag `--proton-pass-share-id`)
+* `AWS_VAULT_PROTON_PASS_ITEM_TITLE_PREFIX`: Prefix to prepend to Proton Pass item titles (see the flag `--proton-pass-item-title-prefix`)
+* `AWS_VAULT_PROTON_PASS_API_BASE`: Proton API base URL (see the flag `--proton-pass-api-base`)
+* `AWS_VAULT_PROTON_PASS_TIMEOUT`: Timeout for Proton Pass API operations (see the flag `--proton-pass-timeout`)
 * `AWS_VAULT_PROFILE_ENV`: Set `AWS_PROFILE` instead of injecting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to allow profile-based SDK auth (see the flag `profile-env` for `exec`)
 * `AWS_CONFIG_FILE`: The location of the AWS config file
 * `AWS_VAULT_STDOUT`: Print login URL to stdout instead of opening in default browser (see the flag `--stdout`)
@@ -334,6 +338,85 @@ If you're looking to configure the amount of time between having to enter your K
 5. Hit save.
 
 ![keychain-image](https://imgur.com/ARkr5Ba.png)
+
+
+### Proton Pass
+
+> ⚠️ Experimental. The `proton-pass` backend talks to an undocumented, internal Proton API and depends on a credential model that may change. Review the Terms of Service note below before using it for anything unattended.
+
+The `proton-pass` backend stores each profile's credentials as an item in a [Proton Pass](https://proton.me/pass) vault, reached directly over Proton's HTTPS API. It does not shell out to the Proton Pass CLI at runtime — you only use the CLI once, to mint and scope the access token.
+
+aws-vault authenticates with a Proton Pass **Personal Access Token (PAT)**, a scoped, Proton-issued automation credential of the form `pst_<token>::<key>`. The whole string is the credential: the `pst_<token>` half is exchanged for a session, and the `::<key>` half is the key that decrypts the vault.
+
+#### 1. Mint and scope a PAT
+
+Install the [Proton Pass CLI](https://github.com/protonpass/pass-cli) and log in, then create a token and grant it access. A dedicated vault keeps aws-vault's items isolated:
+
+```shell
+# Optional: a dedicated vault for aws-vault items
+pass-cli vault create --name aws-vault
+
+# Mint the PAT — the pst_…::… value is printed ONCE; store it now
+# --expiration is one of: 1d, 1w, 1m, 3m, 6m, 1y
+pass-cli pat create --name aws-vault --expiration 3m
+
+# Find the token's <ID>
+pass-cli pat list
+
+# Grant access (see the grant-scope table below for which role/scope you need)
+pass-cli pat access grant --pat-id <ID> --vault-name aws-vault --role editor
+
+# ...or, for least privilege, scope to one already-existing profile item.
+# The item title is "<prefix>/<profile>" (default prefix "aws-vault"):
+pass-cli pat access grant --pat-id <ID> --vault-name aws-vault \
+  --item-title aws-vault/my-profile --role viewer
+```
+
+The grant determines what aws-vault can do, and Proton's role model (`viewer` < `editor` < `manager`) governs the rest:
+
+| Command | Operation | Grant that works |
+| --- | --- | --- |
+| `aws-vault add` | create item | **vault-level `editor`** — the PAT must be a member of the vault; a per-item grant cannot create new items |
+| `aws-vault exec`, `list` | read | per-item grant (read-only `viewer` is enough) |
+| `aws-vault remove` | delete | per-item grant with a writable role (`editor`) |
+
+The `add`-needs-a-vault-level-grant constraint is the one that bites in practice; the read/update/delete rows follow Proton's role model. The simplest setup is a single vault-level `editor` grant, which covers every command. Use a per-item token only when the profile already exists and you want least privilege (for example a read-only `viewer` token on a CI runner that only runs `exec`).
+
+#### 2. Find the Share ID
+
+A grant creates a recipient share for the PAT with its own Share ID. That ID — not the vault owner's — is what aws-vault needs:
+
+```shell
+pass-cli pat access list-access --pat-id <ID>
+```
+
+#### 3. Configure aws-vault
+
+```shell
+export PROTON_PASS_PERSONAL_ACCESS_TOKEN='pst_xxxx::KEY'
+
+aws-vault --backend=proton-pass \
+  --proton-pass-share-id=<SHARE_ID> \
+  add my-profile
+```
+
+Set `AWS_VAULT_BACKEND=proton-pass` and `AWS_VAULT_PROTON_PASS_SHARE_ID=<SHARE_ID>` to avoid repeating the flags. If `PROTON_PASS_PERSONAL_ACCESS_TOKEN` is unset, aws-vault prompts for the token. The token is never accepted as a command-line flag, which would leak it into the process list and shell history.
+
+The backend also reads the Proton Pass CLI's own `PROTON_PASS_SHARE_ID` and `PROTON_PASS_API_BASE` variables as a fallback, so an existing CLI environment works unchanged. The aws-vault-specific `AWS_VAULT_PROTON_PASS_*` variables (and their flags) take precedence when both are set.
+
+#### Session caching and rate limits
+
+The first command exchanges your PAT for a Proton session and caches that session in your **OS keychain** (macOS Keychain, Secret Service, KWallet, or Windows Credential Manager), under a dedicated `aws-vault-proton-pass-session` entry. Subsequent commands reuse it, so a normal `add` → `list` → `exec` sequence performs a single login. The cache entry is keyed to your token, so rotating the PAT invalidates it automatically; a session that Proton has expired or revoked is detected and the PAT re-exchanged on the next call.
+
+This caching is what keeps the backend under Proton's login rate limit. Without it, every command re-runs the full exchange, and a few commands in quick succession trip `HTTP 429 / code 2028 "Too many recent logins"`. On a host with **no OS keychain available** (for example a headless Linux box with no Secret Service), the session cannot be cached and every operation re-exchanges the PAT — space your commands out, or expect the occasional rate-limit error.
+
+`--proton-pass-timeout` (default `30s`, env `AWS_VAULT_PROTON_PASS_TIMEOUT`) bounds each operation, including the several HTTP calls a single command makes.
+
+Errors are reported plainly: a rate-limit response tells you to wait and retry; a rejected PAT tells you to mint or re-grant a token; and a demand for human verification (CAPTCHA / 2FA), which this client cannot satisfy, asks you to re-authenticate with the Proton Pass app or CLI to clear it.
+
+#### Terms of Service
+
+Proton's [Terms of Service](https://proton.me/legal/terms) (Section 2, "Authorized use of the Services") prohibit accessing the Services "through automated means (including but not limited to bots, scripts, or similar technologies)". Interactive use — running `aws-vault exec` yourself, with you present — reads as an unofficial client acting on your behalf. **Unattended or CI use is the gray area for that clause and is at your own risk.** A PAT is the most clearly authorized automation credential Proton offers, but it does not exempt you from the automated-access clause. This is an engineering reading, not legal advice; get sign-off before relying on it for unattended access.
 
 
 ## Managing credentials

--- a/cli/global.go
+++ b/cli/global.go
@@ -30,6 +30,7 @@ var keyringConfigDefaults = keyring.Config{
 	OPTokenEnv:               "AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN",
 	OPDesktopAccountID:       "AWS_VAULT_OP_DESKTOP_ACCOUNT_ID",
 	OPTokenFunc:              keyringPassphrasePrompt,
+	ProtonPassTokenFunc:      keyringPassphrasePrompt,
 }
 
 type AwsVault struct {
@@ -196,6 +197,22 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 	app.Flag("op-desktop-account-id", "1Password Desktop App account name or account UUID").
 		Envar("AWS_VAULT_OP_DESKTOP_ACCOUNT_ID").
 		StringVar(&a.KeyringConfig.OPDesktopAccountID)
+
+	app.Flag("proton-pass-share-id", "Share ID of the Proton Pass vault to use").
+		Envar("AWS_VAULT_PROTON_PASS_SHARE_ID").
+		StringVar(&a.KeyringConfig.ProtonPassShareID)
+
+	app.Flag("proton-pass-item-title-prefix", "Prefix to prepend to Proton Pass item titles (default inherited from keyring)").
+		Envar("AWS_VAULT_PROTON_PASS_ITEM_TITLE_PREFIX").
+		StringVar(&a.KeyringConfig.ProtonPassItemTitlePrefix)
+
+	app.Flag("proton-pass-api-base", "Proton API base URL (default inherited from keyring)").
+		Envar("AWS_VAULT_PROTON_PASS_API_BASE").
+		StringVar(&a.KeyringConfig.ProtonPassAPIBase)
+
+	app.Flag("proton-pass-timeout", "Timeout for Proton Pass API operations (default inherited from keyring)").
+		Envar("AWS_VAULT_PROTON_PASS_TIMEOUT").
+		DurationVar(&a.KeyringConfig.ProtonPassTimeout)
 
 	app.Flag("biometrics", "Use biometric authentication if supported").
 		Envar("AWS_VAULT_BIOMETRICS").


### PR DESCRIPTION
## Summary

- Adds **Proton Pass** as an aws-vault credential backend, backed by the new `proton-pass` backend in `byteness/keyring` v1.12.0 (merged in ByteNess/keyring#98). Each profile is stored as an item in a Proton Pass vault, authenticated with a Personal Access Token (PAT) over native HTTP — no browser, no `pass-cli` subprocess.
- Wires the backend into `cli/global.go`: `--proton-pass-share-id`, `--proton-pass-item-title-prefix`, `--proton-pass-api-base`, and `--proton-pass-timeout`, each with an `AWS_VAULT_PROTON_PASS_*` env var. The PAT comes from `PROTON_PASS_PERSONAL_ACCESS_TOKEN` or the prompt, never a flag (argv-leak avoidance, mirroring the `op-*` backends).
- Documents setup, PAT minting/scoping, Share ID discovery, config, and the experimental/ToS caveats in `USAGE.md`.

## Testing

- `go build` / `go vet` / `go test` green on the default build **and** `-tags keyring_noprotonpass`.
- The backend's crypto, session-cache, and write logic is unit-tested in `byteness/keyring`. Live `add` / `list` / `remove` and an `add → list → exec` burst (confirming the session cache stays under Proton's login rate limit) were verified end-to-end against a throwaway vault.

## Notes for reviewers

- The backend is **experimental**: it targets Proton's unofficial Pass API, which can change without notice (flagged in the keyring README and in `USAGE.md`). Unattended/CI use may bump against Proton's automated-access ToS clause, documented as at the user's own risk.
- `docs/proton-pass-integration.md` is the full design/research record (legal review, clean-room crypto spec, phased plan + outcomes). Happy to trim or drop it if you'd prefer a leaner PR.
- Commits are SSH-signed and show as Verified.
