### PR TITLE
fix: don't prompt for keychain access on every cached session read

### DIFF
--- a/vault/oidctokenkeyring.go
+++ b/vault/oidctokenkeyring.go
@@ -81,12 +81,13 @@ func (o OIDCTokenKeyring) Set(startURL string, token *ssooidc.CreateTokenOutput)
 		return err
 	}
 
+	// Like sessions, the OIDC token is a cache and trusts aws-vault to read it
+	// back without a keychain authorization prompt. See SessionKeyring.Set.
 	return o.Keyring.Set(keyring.Item{
-		Key:                         o.fmtKey(startURL),
-		Data:                        valJSON,
-		Label:                       fmt.Sprintf("aws-vault oidc token for %s (expires %s)", startURL, val.Expiration.Format(time.RFC3339)),
-		Description:                 "aws-vault oidc token",
-		KeychainNotTrustApplication: true,
+		Key:         o.fmtKey(startURL),
+		Data:        valJSON,
+		Label:       fmt.Sprintf("aws-vault oidc token for %s (expires %s)", startURL, val.Expiration.Format(time.RFC3339)),
+		Description: "aws-vault oidc token",
 	})
 }
 

--- a/vault/oidctokenkeyring_test.go
+++ b/vault/oidctokenkeyring_test.go
@@ -1,0 +1,44 @@
+package vault_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
+)
+
+// The cached OIDC token must trust aws-vault so that reading it back doesn't
+// require a keychain authorization prompt (and, when the aws-vault keychain is
+// unlocked with Touch ID, a fingerprint) on every invocation.
+// See https://github.com/ByteNess/aws-vault/issues/421
+func TestOIDCTokenKeyringSetTrustsApplication(t *testing.T) {
+	kr := keyring.NewArrayKeyring(nil)
+	tk := &vault.OIDCTokenKeyring{Keyring: kr}
+
+	startURL := "https://example.awsapps.com/start"
+	err := tk.Set(startURL, &ssooidc.CreateTokenOutput{
+		AccessToken: aws.String("token"),
+		ExpiresIn:   3600,
+	})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 stored item, got %d", len(keys))
+	}
+
+	item, err := kr.Get(keys[0])
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if item.KeychainNotTrustApplication {
+		t.Error("oidc token item was stored with KeychainNotTrustApplication, which prompts for keychain access on every read")
+	}
+}

--- a/vault/sessionkeyring.go
+++ b/vault/sessionkeyring.go
@@ -166,15 +166,18 @@ func (sk *SessionKeyring) Set(key SessionMetadata, creds *ststypes.Credentials) 
 		}
 	}
 
+	// Sessions are a cache, and deliberately trust aws-vault to read them back
+	// without a keychain authorization prompt. Setting
+	// KeychainNotTrustApplication here makes macOS prompt on every read, which
+	// defeats the point of caching: each `aws-vault exec` or credential_process
+	// invocation would require user interaction even when the cached session is
+	// still valid. Long-lived master credentials are the item that stays
+	// untrusted, see CredentialKeyring.Set.
 	return sk.Keyring.Set(keyring.Item{
 		Key:         key.String(),
 		Data:        valJSON,
 		Label:       fmt.Sprintf("aws-vault session for %s (expires %s)", key.ProfileName, creds.Expiration.Format(time.RFC3339)),
 		Description: "aws-vault session",
-		// KeychainNotTrustApplication ensures macOS prompts for
-		// keychain access on every read, consistent with master
-		// credentials stored via CredentialKeyring.
-		KeychainNotTrustApplication: true,
 	})
 }
 

--- a/vault/sessionkeyring_test.go
+++ b/vault/sessionkeyring_test.go
@@ -2,8 +2,12 @@ package vault_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/byteness/aws-vault/v7/vault"
+	"github.com/byteness/keyring"
 )
 
 func TestIsSessionKey(t *testing.T) {
@@ -24,5 +28,42 @@ func TestIsSessionKey(t *testing.T) {
 		} else if !tc.IsSession && vault.IsSessionKey(tc.Key) {
 			t.Fatalf("%q isn't a session key, but was detected as one", tc.Key)
 		}
+	}
+}
+
+// Cached sessions must trust aws-vault so that reading them back doesn't
+// require a keychain authorization prompt (and, when the aws-vault keychain is
+// unlocked with Touch ID, a fingerprint) on every invocation.
+// See https://github.com/ByteNess/aws-vault/issues/421
+func TestSessionKeyringSetTrustsApplication(t *testing.T) {
+	kr := keyring.NewArrayKeyring(nil)
+	sk := &vault.SessionKeyring{Keyring: kr}
+
+	expiry := time.Now().Add(time.Hour)
+	key := vault.SessionMetadata{Type: "sts.GetSessionToken", ProfileName: "llamas"}
+	err := sk.Set(key, &ststypes.Credentials{
+		AccessKeyId:     aws.String("AKID"),
+		SecretAccessKey: aws.String("secret"),
+		SessionToken:    aws.String("token"),
+		Expiration:      &expiry,
+	})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 stored item, got %d", len(keys))
+	}
+
+	item, err := kr.Get(keys[0])
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if item.KeychainNotTrustApplication {
+		t.Error("session item was stored with KeychainNotTrustApplication, which prompts for keychain access on every read")
 	}
 }


### PR DESCRIPTION
Sessions and OIDC tokens were stored with KeychainNotTrustApplication since 4650a0e, which creates the keychain item with an empty trusted application list. macOS then asks the user to authorize access on every read — and on machines where the aws-vault keychain is unlocked with Touch ID, that authorization dialog is a fingerprint prompt.

That defeats the purpose of the session cache: every `aws-vault exec` or `credential_process` invocation needed user interaction even while the cached session was still valid, making scripted use with the AWS CLI impractical. It also applied regardless of --biometrics, so users who never opted into biometrics were affected too.

Store both cache items trusting aws-vault again. Long-lived master credentials keep KeychainNotTrustApplication, which is what the prompt is meant to protect; the `--biometrics` gate on unlocking the keychain is unaffected. Add regression tests covering both item types.

Fixes #421

<!-- What does this PR change and why? Link any related issue. -->
<!--
Thanks for contributing to aws-vault!
Before opening this PR, please make sure you've read:
  - .github/CONTRIBUTING.md
  - AI_POLICY.md  (required if you used ANY AI assistance)
  - SECURITY.md   (do NOT open a public PR/issue for vulnerabilities)
PR title must follow Conventional Commits, e.g.
  feat: add 1Password Service Accounts backend
  fix(server): handle EC2 metadata timeouts cleanly
  docs: clarify pass backend setup on Fedora
-->

### Checklist

- [x] One logical change; unrelated fixes split into separate PRs
- [x] New behaviour has tests; bug fixes include a regression test where practical
- [x] Docs and/or `README.md` updated if the change is user-visible, breaking changes are called out explicitly
- [x] No real credentials, access keys, session tokens, MFA serials, or full account IDs anywhere in the diff, tests, or description
