### PR TITLE
chore(deps): bump keyring to 1.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.3
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3
-	github.com/byteness/keyring v1.12.1
+	github.com/byteness/keyring v1.12.2
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/go-cmp v0.7.0
@@ -25,7 +25,7 @@ require (
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.4-0.20250417152128-c154b387248b // indirect
-	github.com/1password/onepassword-sdk-go v0.4.1-beta.1 // indirect
+	github.com/1password/onepassword-sdk-go v0.4.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/1Password/connect-sdk-go v1.5.4-0.20250417152128-c154b387248b h1:sVddTkAGVmDXJbZKgp+W1zC7hN4lLz9Nus1XmjbY7eo=
 github.com/1Password/connect-sdk-go v1.5.4-0.20250417152128-c154b387248b/go.mod h1:5rSymY4oIYtS4G3t0oMkGAXBeoYiukV3vkqlnEjIDJs=
-github.com/1password/onepassword-sdk-go v0.4.1-beta.1 h1:b/tt+bAXFXR5f3/irmPAaytfmsN6+5Nj6pbsx5nmKZA=
-github.com/1password/onepassword-sdk-go v0.4.1-beta.1/go.mod h1:j/CbzhucTywjlYrd6SE6k0LcQaFZ2l8OLBsAsOYtvD0=
+github.com/1password/onepassword-sdk-go v0.4.1 h1:My/Q2QXemep0I0qHgGrOs7EEzpPh2QZ1/II+S3YqOG0=
+github.com/1password/onepassword-sdk-go v0.4.1/go.mod h1:j/CbzhucTywjlYrd6SE6k0LcQaFZ2l8OLBsAsOYtvD0=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
@@ -54,8 +54,8 @@ github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK1
 github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 h1:j59wGsxaBk6aFBuuYofk2oznMGZYyzFovjDqavlJHM8=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0/go.mod h1:3FrDGTXj08zj6qtqlIvt0vS8eWNrrYpnXOEbcQgFmvM=
-github.com/byteness/keyring v1.12.1 h1:yuxEkx/DN4ndxfS+bBvdtU9kt4jq6drGbqaPiVyngD4=
-github.com/byteness/keyring v1.12.1/go.mod h1:quaPM9E2ILA4z2ET+BiJp1lR/Djk4pdgSMIlzMXF5Iw=
+github.com/byteness/keyring v1.12.2 h1:7hRHeaPUz1xzqFVdVKMlsZIvvq47nWkfI5q5UbMyOUU=
+github.com/byteness/keyring v1.12.2/go.mod h1:TNy8MloC02n5fFVklTp8ejrAHUl5NMIwZ49xFTG4duE=
 github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=
 github.com/byteness/percent v0.2.2/go.mod h1:nwavge92FhIyfnldz4YWZD8uxPVvdh8NlzLRd1VYRDs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue - required
for anything beyond a typo, doc clarification, or obvious bug fix - and
ALWAYS required if AI was involved (see AI_POLICY.md).

Drive-by AI PRs are closed!

Before opening this PR, please make sure you've read:
  - .github/CONTRIBUTING.md
  - AI_POLICY.md  (required if you used ANY AI assistance)
  - SECURITY.md   (do NOT open a public PR/issue for vulnerabilities)
PR title must follow Conventional Commits, e.g.
  feat: add 1Password Service Accounts backend
  fix(server): handle EC2 metadata timeouts cleanly
  docs: clarify pass backend setup on Fedora

Thanks for contributing to aws-vault!
-->

Bump to latest `keyring`, which is out of beta and also removes CGO requirement for Darwin.

### Checklist

- [x] One logical change; unrelated fixes split into separate PRs
- [x] New behaviour has tests; bug fixes include a regression test where practical
- [x] Docs and/or `README.md` updated if the change is user-visible, breaking changes are called out explicitly
- [x] No real credentials, access keys, session tokens, MFA serials, or full account IDs anywhere in the diff, tests, or description
