### PR TITLE
feat: support AWS_VAULT_DURATION env var for --duration flag

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -75,6 +75,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 
 	cmd.Flag("duration", "Duration of the temporary or assume-role session. Defaults to 1h").
 		Short('d').
+		Envar("AWS_VAULT_DURATION").
 		DurationVar(&input.SessionDuration)
 
 	cmd.Flag("no-session", "Skip creating STS session with GetSessionToken").

--- a/cli/export.go
+++ b/cli/export.go
@@ -39,6 +39,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 
 	cmd.Flag("duration", "Duration of the temporary or assume-role session. Defaults to 1h").
 		Short('d').
+		Envar("AWS_VAULT_DURATION").
 		DurationVar(&input.SessionDuration)
 
 	cmd.Flag("no-session", "Skip creating STS session with GetSessionToken").

--- a/cli/login.go
+++ b/cli/login.go
@@ -39,6 +39,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 
 	cmd.Flag("duration", "Duration of the assume-role or federated session. Defaults to 1h").
 		Short('d').
+		Envar("AWS_VAULT_DURATION").
 		DurationVar(&input.SessionDuration)
 
 	cmd.Flag("no-session", "Skip creating STS session with GetSessionToken").

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -133,6 +133,7 @@ To configure the default flag values of `aws-vault` and its subcommands:
 | `AWS_VAULT_PASS_PREFIX` | Prefix to prepend to the item path stored in pass | `--pass-prefix` |
 | `AWS_VAULT_FILE_DIR` | Directory for the "file" password store | `--file-dir` |
 | `AWS_VAULT_FILE_PASSPHRASE` | Password for the "file" password store | — |
+| `AWS_VAULT_DURATION` | Duration of the temporary or assume-role session | `--duration` |
 | `AWS_VAULT_OP_TIMEOUT` | Timeout for 1Password Service Account operations | `--op-timeout` |
 | `AWS_VAULT_OP_VAULT_ID` | UUID of the 1Password vault | `--op-vault-id` |
 | `AWS_VAULT_OP_ITEM_TITLE_PREFIX` | Prefix to prepend to 1Password item titles | `--op-item-title-prefix` |


### PR DESCRIPTION
Adds `AWS_VAULT_DURATION` env var support to the `--duration` flag across `exec`, `export`, and `login`, matching the existing `Envar()` convention used by other aws-vault flags (e.g. `AWS_VAULT_BACKEND`).

```diff
 cmd.Flag("duration", ...).
     Short('d').
+    Envar("AWS_VAULT_DURATION").
     DurationVar(&input.SessionDuration)
```

Also documents the new env var in `docs/content/docs/config.md` (the env-var table that replaced the former `USAGE.md` list in this fork).

This is a re-target of https://github.com/99designs/aws-vault/pull/1277 to the maintained ByteNess fork. The three `cli/*.go` hunks apply unchanged; only the documentation location was adapted to this fork's current docs structure.
