### PR TITLE
feat: support separate session keyrings and Passage identity files

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -35,7 +35,7 @@ func ConfigureAddCommand(app *kingpin.Application, a *AwsVault) {
 		BoolVar(&input.AddConfig)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -43,13 +43,13 @@ func ConfigureAddCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		err = AddCommand(input, keyring, awsConfigFile)
+		err = AddCommand(input, keyring, sessionKeyring, awsConfigFile)
 		app.FatalIfError(err, "add")
 		return nil
 	})
 }
 
-func AddCommand(input AddCommandInput, keyring keyring.Keyring, awsConfigFile *vault.ConfigFile) error {
+func AddCommand(input AddCommandInput, keyring, sessionKeyring keyring.Keyring, awsConfigFile *vault.ConfigFile) error {
 	var accessKeyID, secretKey, mfaSerial string
 
 	p, _ := awsConfigFile.ProfileSection(input.ProfileName)
@@ -87,7 +87,7 @@ func AddCommand(input AddCommandInput, keyring keyring.Keyring, awsConfigFile *v
 
 	fmt.Printf("Added credentials to profile %q in vault\n", input.ProfileName)
 
-	sk := &vault.SessionKeyring{Keyring: keyring}
+	sk := &vault.SessionKeyring{Keyring: sessionKeyring}
 	if n, _ := sk.RemoveForProfile(input.ProfileName); n > 0 {
 		fmt.Printf("Deleted %d existing sessions.\n", n)
 	}

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -22,7 +22,7 @@ func ConfigureClearCommand(app *kingpin.Application, a *AwsVault) {
 		StringVar(&input.ProfileName)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -31,14 +31,14 @@ func ConfigureClearCommand(app *kingpin.Application, a *AwsVault) {
 			return err
 		}
 
-		err = ClearCommand(input, awsConfigFile, keyring)
+		err = ClearCommand(input, awsConfigFile, keyring, sessionKeyring)
 		app.FatalIfError(err, "clear")
 		return nil
 	})
 }
 
-func ClearCommand(input ClearCommandInput, awsConfigFile *vault.ConfigFile, keyring keyring.Keyring) error {
-	sessions := &vault.SessionKeyring{Keyring: keyring}
+func ClearCommand(input ClearCommandInput, awsConfigFile *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) error {
+	sessions := &vault.SessionKeyring{Keyring: sessionKeyring}
 	oidcTokens := &vault.OIDCTokenKeyring{Keyring: keyring}
 	var oldSessionsRemoved, numSessionsRemoved, numTokensRemoved int
 	var err error

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -38,29 +38,19 @@ func ConfigureClearCommand(app *kingpin.Application, a *AwsVault) {
 }
 
 func ClearCommand(input ClearCommandInput, awsConfigFile *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) error {
-	sessions := &vault.SessionKeyring{Keyring: sessionKeyring}
+	numSessionsRemoved, err := clearSessions(input, keyring)
+	if err != nil {
+		return err
+	}
+
 	oidcTokens := &vault.OIDCTokenKeyring{Keyring: keyring}
-	var oldSessionsRemoved, numSessionsRemoved, numTokensRemoved int
-	var err error
+	var numTokensRemoved int
 	if input.ProfileName == "" {
-		oldSessionsRemoved, err = sessions.RemoveOldSessions()
-		if err != nil {
-			return err
-		}
-		numSessionsRemoved, err = sessions.RemoveAll()
-		if err != nil {
-			return err
-		}
 		numTokensRemoved, err = oidcTokens.RemoveAll()
 		if err != nil {
 			return err
 		}
 	} else {
-		numSessionsRemoved, err = sessions.RemoveForProfile(input.ProfileName)
-		if err != nil {
-			return err
-		}
-
 		if profileSection, ok := awsConfigFile.ProfileSection(input.ProfileName); ok {
 			startURL := awsConfigFile.ResolvedSSOStartURL(profileSection)
 			if startURL != "" {
@@ -74,7 +64,30 @@ func ClearCommand(input ClearCommandInput, awsConfigFile *vault.ConfigFile, keyr
 			}
 		}
 	}
-	fmt.Printf("Cleared %d sessions.\n", oldSessionsRemoved+numSessionsRemoved+numTokensRemoved)
+
+	if keyring != sessionKeyring {
+		n, err := clearSessions(input, sessionKeyring)
+		if err != nil {
+			return err
+		}
+		numSessionsRemoved += n
+	}
+
+	fmt.Printf("Cleared %d sessions.\n", numSessionsRemoved+numTokensRemoved)
 
 	return nil
+}
+
+func clearSessions(input ClearCommandInput, keyring keyring.Keyring) (int, error) {
+	sessions := &vault.SessionKeyring{Keyring: keyring}
+	if input.ProfileName != "" {
+		return sessions.RemoveForProfile(input.ProfileName)
+	}
+
+	oldSessionsRemoved, err := sessions.RemoveOldSessions()
+	if err != nil {
+		return 0, err
+	}
+	numSessionsRemoved, err := sessions.RemoveAll()
+	return oldSessionsRemoved + numSessionsRemoved, err
 }

--- a/cli/clear_test.go
+++ b/cli/clear_test.go
@@ -70,33 +70,38 @@ func TestClearCommandBothSetPrefersSSOSession(t *testing.T) {
 	}
 }
 
-func TestClearCommandUsesSeparateSessionKeyring(t *testing.T) {
+func TestClearCommandClearsSessionsFromBothKeyrings(t *testing.T) {
 	const startURL = "https://example.awsapps.com/start"
 	configFile := writeTempConfig(t, listTestConfig)
 	primary := keyring.NewArrayKeyring([]keyring.Item{
 		{Key: "oidc:" + startURL, Data: []byte(`{}`)},
 	})
 	sessions := keyring.NewArrayKeyring(nil)
-	sessionKeyring := &vault.SessionKeyring{Keyring: sessions}
 	expires := time.Now().Add(time.Hour)
-	if err := sessionKeyring.Set(vault.SessionMetadata{
-		Type:        "sts.GetSessionToken",
-		ProfileName: "sso-profile",
-	}, &ststypes.Credentials{
-		AccessKeyId:     aws.String("AKIAEXAMPLE"),
-		SecretAccessKey: aws.String("secret"),
-		SessionToken:    aws.String("token"),
-		Expiration:      &expires,
-	}); err != nil {
-		t.Fatal(err)
+	for _, kr := range []keyring.Keyring{primary, sessions} {
+		sessionKeyring := &vault.SessionKeyring{Keyring: kr}
+		if err := sessionKeyring.Set(vault.SessionMetadata{
+			Type:        "sts.GetSessionToken",
+			ProfileName: "sso-profile",
+		}, &ststypes.Credentials{
+			AccessKeyId:     aws.String("AKIAEXAMPLE"),
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+			Expiration:      &expires,
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if err := ClearCommand(ClearCommandInput{ProfileName: "sso-profile"}, configFile, primary, sessions); err != nil {
 		t.Fatalf("ClearCommand error: %v", err)
 	}
 
-	if keys, err := sessions.Keys(); err != nil || len(keys) != 0 {
-		t.Fatalf("session keyring still contains %v, err: %v", keys, err)
+	for _, kr := range []keyring.Keyring{primary, sessions} {
+		keys, err := (&vault.SessionKeyring{Keyring: kr}).Keys()
+		if err != nil || len(keys) != 0 {
+			t.Fatalf("keyring still contains sessions %v, err: %v", keys, err)
+		}
 	}
 	if has, err := (&vault.OIDCTokenKeyring{Keyring: primary}).Has(startURL); err != nil || has {
 		t.Fatalf("OIDC token was not removed from primary keyring, has: %v, err: %v", has, err)

--- a/cli/clear_test.go
+++ b/cli/clear_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/byteness/aws-vault/v7/vault"
 	"github.com/byteness/keyring"
 )
@@ -29,7 +32,7 @@ func TestClearCommandModernOIDC(t *testing.T) {
 		t.Fatal("expected OIDC token in keyring before clear")
 	}
 
-	if err := ClearCommand(ClearCommandInput{ProfileName: "sso-profile"}, configFile, kr); err != nil {
+	if err := ClearCommand(ClearCommandInput{ProfileName: "sso-profile"}, configFile, kr, kr); err != nil {
 		t.Fatalf("ClearCommand error: %v", err)
 	}
 
@@ -54,7 +57,7 @@ func TestClearCommandBothSetPrefersSSOSession(t *testing.T) {
 	})
 	oidcKeyring := &vault.OIDCTokenKeyring{Keyring: kr}
 
-	if err := ClearCommand(ClearCommandInput{ProfileName: "both-profile"}, configFile, kr); err != nil {
+	if err := ClearCommand(ClearCommandInput{ProfileName: "both-profile"}, configFile, kr, kr); err != nil {
 		t.Fatalf("ClearCommand error: %v", err)
 	}
 
@@ -64,5 +67,38 @@ func TestClearCommandBothSetPrefersSSOSession(t *testing.T) {
 	}
 	if has {
 		t.Error("ClearCommand left the sso-session token behind; it resolved the inline url instead")
+	}
+}
+
+func TestClearCommandUsesSeparateSessionKeyring(t *testing.T) {
+	const startURL = "https://example.awsapps.com/start"
+	configFile := writeTempConfig(t, listTestConfig)
+	primary := keyring.NewArrayKeyring([]keyring.Item{
+		{Key: "oidc:" + startURL, Data: []byte(`{}`)},
+	})
+	sessions := keyring.NewArrayKeyring(nil)
+	sessionKeyring := &vault.SessionKeyring{Keyring: sessions}
+	expires := time.Now().Add(time.Hour)
+	if err := sessionKeyring.Set(vault.SessionMetadata{
+		Type:        "sts.GetSessionToken",
+		ProfileName: "sso-profile",
+	}, &ststypes.Credentials{
+		AccessKeyId:     aws.String("AKIAEXAMPLE"),
+		SecretAccessKey: aws.String("secret"),
+		SessionToken:    aws.String("token"),
+		Expiration:      &expires,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ClearCommand(ClearCommandInput{ProfileName: "sso-profile"}, configFile, primary, sessions); err != nil {
+		t.Fatalf("ClearCommand error: %v", err)
+	}
+
+	if keys, err := sessions.Keys(); err != nil || len(keys) != 0 {
+		t.Fatalf("session keyring still contains %v, err: %v", keys, err)
+	}
+	if has, err := (&vault.OIDCTokenKeyring{Keyring: primary}).Has(startURL); err != nil || has {
+		t.Fatalf("OIDC token was not removed from primary keyring, has: %v, err: %v", has, err)
 	}
 }

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -139,7 +139,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -165,9 +165,9 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 				NoSession:       input.NoSession,
 			}
 
-			err = ExportCommand(exportCommandInput, f, keyring)
+			err = ExportCommand(exportCommandInput, f, keyring, sessionKeyring)
 		} else {
-			exitcode, err = ExecCommand(input, f, keyring)
+			exitcode, err = ExecCommand(input, f, keyring, sessionKeyring)
 		}
 
 		app.FatalIfError(err, "exec")
@@ -179,7 +179,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *AwsVault) {
 	})
 }
 
-func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) (exitcode int, err error) {
+func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) (exitcode int, err error) {
 	if os.Getenv("AWS_VAULT") != "" {
 		return 0, fmt.Errorf("running in an existing aws-vault subshell; 'exit' from the subshell or unset AWS_VAULT to force")
 	}
@@ -198,7 +198,7 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 	}
 
 	ckr := &vault.CredentialKeyring{Keyring: keyring}
-	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr, input.NoSession, false)
+	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr, sessionKeyring, input.NoSession, false)
 	if err != nil {
 		return 0, fmt.Errorf("Error getting temporary credentials: %w", err)
 	}

--- a/cli/export.go
+++ b/cli/export.go
@@ -77,7 +77,7 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -93,13 +93,13 @@ func ConfigureExportCommand(app *kingpin.Application, a *AwsVault) {
 			input.ProfileName = ProfileName
 		}
 
-		err = ExportCommand(input, f, keyring)
+		err = ExportCommand(input, f, keyring, sessionKeyring)
 		app.FatalIfError(err, "export")
 		return nil
 	})
 }
 
-func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) error {
 	if os.Getenv("AWS_VAULT") != "" {
 		return fmt.Errorf("in an existing aws-vault subshell; 'exit' from the subshell or unset AWS_VAULT to force")
 	}
@@ -114,7 +114,7 @@ func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring keyrin
 	}
 
 	ckr := &vault.CredentialKeyring{Keyring: keyring}
-	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr, input.NoSession, false)
+	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr, sessionKeyring, input.NoSession, false)
 	if err != nil {
 		return fmt.Errorf("Error getting temporary credentials: %w", err)
 	}

--- a/cli/global.go
+++ b/cli/global.go
@@ -33,15 +33,63 @@ var keyringConfigDefaults = keyring.Config{
 	ProtonPassTokenFunc:      keyringPassphrasePrompt,
 }
 
-type AwsVault struct {
-	Debug          bool
-	KeyringConfig  keyring.Config
-	KeyringBackend string
-	promptDriver   string
+type keyringConfigOverrides struct {
+	KeychainName            string
+	LibSecretCollectionName string
+	PassDir                 string
+	PassCmd                 string
+	PassPrefix              string
+	PassageIdentitiesFile   string
+	FileDir                 string
+}
 
-	keyringImpl   keyring.Keyring
-	awsConfigFile *vault.ConfigFile
-	UseBiometrics bool
+func (o keyringConfigOverrides) configured() bool {
+	return o.KeychainName != "" ||
+		o.LibSecretCollectionName != "" ||
+		o.PassDir != "" ||
+		o.PassCmd != "" ||
+		o.PassPrefix != "" ||
+		o.PassageIdentitiesFile != "" ||
+		o.FileDir != ""
+}
+
+func (o keyringConfigOverrides) apply(config keyring.Config) keyring.Config {
+	if o.KeychainName != "" {
+		config.KeychainName = o.KeychainName
+	}
+	if o.LibSecretCollectionName != "" {
+		config.LibSecretCollectionName = o.LibSecretCollectionName
+	}
+	if o.PassDir != "" {
+		config.PassDir = o.PassDir
+	}
+	if o.PassCmd != "" {
+		config.PassCmd = o.PassCmd
+	}
+	if o.PassPrefix != "" {
+		config.PassPrefix = o.PassPrefix
+	}
+	if o.PassageIdentitiesFile != "" {
+		config.PassageIdentitiesFile = o.PassageIdentitiesFile
+	}
+	if o.FileDir != "" {
+		config.FileDir = o.FileDir
+	}
+	return config
+}
+
+type AwsVault struct {
+	Debug                   bool
+	KeyringConfig           keyring.Config
+	KeyringBackend          string
+	SessionKeyringBackend   string
+	promptDriver            string
+	sessionKeyringOverrides keyringConfigOverrides
+
+	keyringImpl        keyring.Keyring
+	sessionKeyringImpl keyring.Keyring
+	awsConfigFile      *vault.ConfigFile
+	UseBiometrics      bool
 }
 
 func isATerminal() bool {
@@ -81,6 +129,43 @@ func (a *AwsVault) Keyring() (keyring.Keyring, error) {
 	}
 
 	return a.keyringImpl, nil
+}
+
+func (a *AwsVault) SessionKeyring() (keyring.Keyring, error) {
+	if a.SessionKeyringBackend == "" && !a.sessionKeyringOverrides.configured() {
+		return a.Keyring()
+	}
+
+	if a.sessionKeyringImpl == nil {
+		config := a.sessionKeyringOverrides.apply(a.KeyringConfig)
+		backend := a.KeyringBackend
+		if a.SessionKeyringBackend != "" {
+			backend = a.SessionKeyringBackend
+		}
+		if backend != "" {
+			config.AllowedBackends = []keyring.BackendType{keyring.BackendType(backend)}
+		}
+
+		var err error
+		a.sessionKeyringImpl, err = keyring.Open(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return a.sessionKeyringImpl, nil
+}
+
+func (a *AwsVault) Keyrings() (keyring.Keyring, keyring.Keyring, error) {
+	credentials, err := a.Keyring()
+	if err != nil {
+		return nil, nil, err
+	}
+	sessions, err := a.SessionKeyring()
+	if err != nil {
+		return nil, nil, err
+	}
+	return credentials, sessions, nil
 }
 
 func (a *AwsVault) AwsConfigFile() (*vault.ConfigFile, error) {
@@ -123,6 +208,10 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		Envar("AWS_VAULT_BACKEND").
 		EnumVar(&a.KeyringBackend, backendsAvailable...)
 
+	app.Flag("session-backend", fmt.Sprintf("Secret backend to use for sessions %v", backendsAvailable)).
+		Envar("AWS_VAULT_SESSION_BACKEND").
+		EnumVar(&a.SessionKeyringBackend, backendsAvailable...)
+
 	app.Flag("prompt", fmt.Sprintf("Prompt driver to use %v", promptsAvailable)).
 		Envar("AWS_VAULT_PROMPT").
 		StringVar(&a.promptDriver)
@@ -149,27 +238,59 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		Envar("AWS_VAULT_KEYCHAIN_NAME").
 		StringVar(&a.KeyringConfig.KeychainName)
 
+	app.Flag("session-keychain", "Name of macOS keychain to use for sessions").
+		Envar("AWS_VAULT_SESSION_KEYCHAIN_NAME").
+		StringVar(&a.sessionKeyringOverrides.KeychainName)
+
 	app.Flag("secret-service-collection", "Name of secret-service collection to use, if it doesn't exist it will be created").
 		Default("awsvault").
 		Envar("AWS_VAULT_SECRET_SERVICE_COLLECTION_NAME").
 		StringVar(&a.KeyringConfig.LibSecretCollectionName)
 
+	app.Flag("session-secret-service-collection", "Name of secret-service collection to use for sessions").
+		Envar("AWS_VAULT_SESSION_SECRET_SERVICE_COLLECTION_NAME").
+		StringVar(&a.sessionKeyringOverrides.LibSecretCollectionName)
+
 	app.Flag("pass-dir", "Pass password store directory").
 		Envar("AWS_VAULT_PASS_PASSWORD_STORE_DIR").
 		StringVar(&a.KeyringConfig.PassDir)
+
+	app.Flag("session-pass-dir", "Pass password store directory to use for sessions").
+		Envar("AWS_VAULT_SESSION_PASS_PASSWORD_STORE_DIR").
+		StringVar(&a.sessionKeyringOverrides.PassDir)
 
 	app.Flag("pass-cmd", "Name of the pass executable").
 		Envar("AWS_VAULT_PASS_CMD").
 		StringVar(&a.KeyringConfig.PassCmd)
 
+	app.Flag("session-pass-cmd", "Name of the pass executable to use for sessions").
+		Envar("AWS_VAULT_SESSION_PASS_CMD").
+		StringVar(&a.sessionKeyringOverrides.PassCmd)
+
 	app.Flag("pass-prefix", "Prefix to prepend to the item path stored in pass").
 		Envar("AWS_VAULT_PASS_PREFIX").
 		StringVar(&a.KeyringConfig.PassPrefix)
+
+	app.Flag("session-pass-prefix", "Prefix to prepend to session item paths stored in pass").
+		Envar("AWS_VAULT_SESSION_PASS_PREFIX").
+		StringVar(&a.sessionKeyringOverrides.PassPrefix)
+
+	app.Flag("passage-identities-file", "Passage identities file").
+		Envar("AWS_VAULT_PASSAGE_IDENTITIES_FILE").
+		StringVar(&a.KeyringConfig.PassageIdentitiesFile)
+
+	app.Flag("session-passage-identities-file", "Passage identities file to use for sessions").
+		Envar("AWS_VAULT_SESSION_PASSAGE_IDENTITIES_FILE").
+		StringVar(&a.sessionKeyringOverrides.PassageIdentitiesFile)
 
 	app.Flag("file-dir", "Directory for the \"file\" password store").
 		Default("~/.awsvault/keys/").
 		Envar("AWS_VAULT_FILE_DIR").
 		StringVar(&a.KeyringConfig.FileDir)
+
+	app.Flag("session-file-dir", "Directory for the session \"file\" password store").
+		Envar("AWS_VAULT_SESSION_FILE_DIR").
+		StringVar(&a.sessionKeyringOverrides.FileDir)
 
 	app.Flag("op-timeout", "Timeout for 1Password API operations (1Password Service Accounts only)").
 		Default("15s").

--- a/cli/global.go
+++ b/cli/global.go
@@ -34,13 +34,18 @@ var keyringConfigDefaults = keyring.Config{
 }
 
 type keyringConfigOverrides struct {
-	KeychainName            string
-	LibSecretCollectionName string
-	PassDir                 string
-	PassCmd                 string
-	PassPrefix              string
-	PassageIdentitiesFile   string
-	FileDir                 string
+	KeychainName              string
+	LibSecretCollectionName   string
+	PassDir                   string
+	PassCmd                   string
+	PassPrefix                string
+	PassageIdentitiesFile     string
+	FileDir                   string
+	OPVaultID                 string
+	OPItemTitlePrefix         string
+	OPItemTag                 string
+	ProtonPassShareID         string
+	ProtonPassItemTitlePrefix string
 }
 
 func (o keyringConfigOverrides) configured() bool {
@@ -50,7 +55,12 @@ func (o keyringConfigOverrides) configured() bool {
 		o.PassCmd != "" ||
 		o.PassPrefix != "" ||
 		o.PassageIdentitiesFile != "" ||
-		o.FileDir != ""
+		o.FileDir != "" ||
+		o.OPVaultID != "" ||
+		o.OPItemTitlePrefix != "" ||
+		o.OPItemTag != "" ||
+		o.ProtonPassShareID != "" ||
+		o.ProtonPassItemTitlePrefix != ""
 }
 
 func (o keyringConfigOverrides) apply(config keyring.Config) keyring.Config {
@@ -74,6 +84,21 @@ func (o keyringConfigOverrides) apply(config keyring.Config) keyring.Config {
 	}
 	if o.FileDir != "" {
 		config.FileDir = o.FileDir
+	}
+	if o.OPVaultID != "" {
+		config.OPVaultID = o.OPVaultID
+	}
+	if o.OPItemTitlePrefix != "" {
+		config.OPItemTitlePrefix = o.OPItemTitlePrefix
+	}
+	if o.OPItemTag != "" {
+		config.OPItemTag = o.OPItemTag
+	}
+	if o.ProtonPassShareID != "" {
+		config.ProtonPassShareID = o.ProtonPassShareID
+	}
+	if o.ProtonPassItemTitlePrefix != "" {
+		config.ProtonPassItemTitlePrefix = o.ProtonPassItemTitlePrefix
 	}
 	return config
 }
@@ -301,15 +326,27 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		Envar("AWS_VAULT_OP_VAULT_ID").
 		StringVar(&a.KeyringConfig.OPVaultID)
 
+	app.Flag("session-op-vault-id", "UUID of the 1Password vault to use for sessions").
+		Envar("AWS_VAULT_SESSION_OP_VAULT_ID").
+		StringVar(&a.sessionKeyringOverrides.OPVaultID)
+
 	app.Flag("op-item-title-prefix", "Prefix to prepend to 1Password item titles").
 		Default("aws-vault").
 		Envar("AWS_VAULT_OP_ITEM_TITLE_PREFIX").
 		StringVar(&a.KeyringConfig.OPItemTitlePrefix)
 
+	app.Flag("session-op-item-title-prefix", "Prefix to prepend to 1Password session item titles").
+		Envar("AWS_VAULT_SESSION_OP_ITEM_TITLE_PREFIX").
+		StringVar(&a.sessionKeyringOverrides.OPItemTitlePrefix)
+
 	app.Flag("op-item-tag", "Tag to apply to 1Password items").
 		Default("aws-vault").
 		Envar("AWS_VAULT_OP_ITEM_TAG").
 		StringVar(&a.KeyringConfig.OPItemTag)
+
+	app.Flag("session-op-item-tag", "Tag to apply to 1Password session items").
+		Envar("AWS_VAULT_SESSION_OP_ITEM_TAG").
+		StringVar(&a.sessionKeyringOverrides.OPItemTag)
 
 	app.Flag("op-connect-host", "1Password Connect server HTTP(S) URI").
 		Envar("AWS_VAULT_OP_CONNECT_HOST").
@@ -323,9 +360,17 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		Envar("AWS_VAULT_PROTON_PASS_SHARE_ID").
 		StringVar(&a.KeyringConfig.ProtonPassShareID)
 
+	app.Flag("session-proton-pass-share-id", "Share ID of the Proton Pass vault to use for sessions").
+		Envar("AWS_VAULT_SESSION_PROTON_PASS_SHARE_ID").
+		StringVar(&a.sessionKeyringOverrides.ProtonPassShareID)
+
 	app.Flag("proton-pass-item-title-prefix", "Prefix to prepend to Proton Pass item titles (default inherited from keyring)").
 		Envar("AWS_VAULT_PROTON_PASS_ITEM_TITLE_PREFIX").
 		StringVar(&a.KeyringConfig.ProtonPassItemTitlePrefix)
+
+	app.Flag("session-proton-pass-item-title-prefix", "Prefix to prepend to Proton Pass session item titles").
+		Envar("AWS_VAULT_SESSION_PROTON_PASS_ITEM_TITLE_PREFIX").
+		StringVar(&a.sessionKeyringOverrides.ProtonPassItemTitlePrefix)
 
 	app.Flag("proton-pass-api-base", "Proton API base URL (default inherited from keyring)").
 		Envar("AWS_VAULT_PROTON_PASS_API_BASE").

--- a/cli/global_test.go
+++ b/cli/global_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/byteness/aws-vault/v7/vault"
 	"github.com/byteness/keyring"
 )
@@ -79,6 +80,78 @@ func TestProfileResolvable(t *testing.T) {
 	}
 }
 
+func TestSessionKeyringDefaultsToPrimaryKeyring(t *testing.T) {
+	primary := keyring.NewArrayKeyring(nil)
+	a := &AwsVault{keyringImpl: primary}
+
+	sessions, err := a.SessionKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions != primary {
+		t.Fatal("expected sessions to use the primary keyring by default")
+	}
+}
+
+func TestSessionKeyringOverridesInheritPrimaryConfig(t *testing.T) {
+	primary := keyring.Config{
+		PassDir:                 "/primary/store",
+		PassPrefix:              "credentials",
+		PassageIdentitiesFile:   "/primary/identities",
+		LibSecretCollectionName: "primary",
+	}
+	overrides := keyringConfigOverrides{
+		PassPrefix:            "sessions",
+		PassageIdentitiesFile: "/session/identities",
+	}
+
+	sessions := overrides.apply(primary)
+	if sessions.PassDir != primary.PassDir {
+		t.Fatalf("PassDir = %q, want inherited value %q", sessions.PassDir, primary.PassDir)
+	}
+	if sessions.LibSecretCollectionName != primary.LibSecretCollectionName {
+		t.Fatalf("LibSecretCollectionName = %q, want inherited value %q", sessions.LibSecretCollectionName, primary.LibSecretCollectionName)
+	}
+	if sessions.PassPrefix != overrides.PassPrefix {
+		t.Fatalf("PassPrefix = %q, want override %q", sessions.PassPrefix, overrides.PassPrefix)
+	}
+	if sessions.PassageIdentitiesFile != overrides.PassageIdentitiesFile {
+		t.Fatalf("PassageIdentitiesFile = %q, want override %q", sessions.PassageIdentitiesFile, overrides.PassageIdentitiesFile)
+	}
+	if primary.PassPrefix != "credentials" || primary.PassageIdentitiesFile != "/primary/identities" {
+		t.Fatal("applying session overrides modified the primary config")
+	}
+}
+
+func TestSessionKeyringEnvironmentConfiguration(t *testing.T) {
+	backend := string(keyring.AvailableBackends()[0])
+	t.Setenv("AWS_VAULT_BACKEND", backend)
+	t.Setenv("AWS_VAULT_PASSAGE_IDENTITIES_FILE", "/primary/identities")
+	t.Setenv("AWS_VAULT_SESSION_BACKEND", backend)
+	t.Setenv("AWS_VAULT_SESSION_PASS_PREFIX", "sessions")
+	t.Setenv("AWS_VAULT_SESSION_PASSAGE_IDENTITIES_FILE", "/session/identities")
+
+	app := kingpin.New("aws-vault", "")
+	a := ConfigureGlobals(app)
+	app.Command("noop", "")
+	if _, err := app.Parse([]string{"noop"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if a.KeyringConfig.PassageIdentitiesFile != "/primary/identities" {
+		t.Fatalf("primary PassageIdentitiesFile = %q", a.KeyringConfig.PassageIdentitiesFile)
+	}
+	if a.SessionKeyringBackend != backend {
+		t.Fatalf("session backend = %q, want %q", a.SessionKeyringBackend, backend)
+	}
+	if a.sessionKeyringOverrides.PassPrefix != "sessions" {
+		t.Fatalf("session PassPrefix = %q", a.sessionKeyringOverrides.PassPrefix)
+	}
+	if a.sessionKeyringOverrides.PassageIdentitiesFile != "/session/identities" {
+		t.Fatalf("session PassageIdentitiesFile = %q", a.sessionKeyringOverrides.PassageIdentitiesFile)
+	}
+}
+
 // TestExecCommandRejectsMissingProfile is the regression test for issue #377:
 // exec must error on a non-existent profile rather than silently inheriting
 // [default]. The guard fires before any config load or execve, so calling
@@ -88,7 +161,7 @@ func TestExecCommandRejectsMissingProfile(t *testing.T) {
 	configFile := writeTempConfig(t, issue377Config)
 	kr := keyring.NewArrayKeyring([]keyring.Item{})
 
-	_, err := ExecCommand(ExecCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr)
+	_, err := ExecCommand(ExecCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr, kr)
 	if err == nil {
 		t.Fatal("ExecCommand accepted a non-existent profile; expected an error (issue #377)")
 	}
@@ -104,7 +177,7 @@ func TestExportCommandRejectsMissingProfile(t *testing.T) {
 	configFile := writeTempConfig(t, issue377Config)
 	kr := keyring.NewArrayKeyring([]keyring.Item{})
 
-	err := ExportCommand(ExportCommandInput{ProfileName: "invalid-profile", Format: FormatTypeEnv, NoSession: true}, configFile, kr)
+	err := ExportCommand(ExportCommandInput{ProfileName: "invalid-profile", Format: FormatTypeEnv, NoSession: true}, configFile, kr, kr)
 	if err == nil {
 		t.Fatal("ExportCommand accepted a non-existent profile; expected an error (issue #377)")
 	}
@@ -119,7 +192,7 @@ func TestRotateCommandRejectsMissingProfile(t *testing.T) {
 	configFile := writeTempConfig(t, issue377Config)
 	kr := keyring.NewArrayKeyring([]keyring.Item{})
 
-	err := RotateCommand(RotateCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr)
+	err := RotateCommand(RotateCommandInput{ProfileName: "invalid-profile", NoSession: true}, configFile, kr, kr)
 	if err == nil {
 		t.Fatal("RotateCommand accepted a non-existent profile; expected an error (issue #377)")
 	}

--- a/cli/global_test.go
+++ b/cli/global_test.go
@@ -93,16 +93,47 @@ func TestSessionKeyringDefaultsToPrimaryKeyring(t *testing.T) {
 	}
 }
 
+func TestSessionKeyringOverridesConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides keyringConfigOverrides
+	}{
+		{"1Password vault ID", keyringConfigOverrides{OPVaultID: "session-vault"}},
+		{"1Password item title prefix", keyringConfigOverrides{OPItemTitlePrefix: "sessions"}},
+		{"1Password item tag", keyringConfigOverrides{OPItemTag: "sessions"}},
+		{"Proton Pass share ID", keyringConfigOverrides{ProtonPassShareID: "session-share"}},
+		{"Proton Pass item title prefix", keyringConfigOverrides{ProtonPassItemTitlePrefix: "sessions"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.overrides.configured() {
+				t.Fatal("session override was not detected")
+			}
+		})
+	}
+}
+
 func TestSessionKeyringOverridesInheritPrimaryConfig(t *testing.T) {
 	primary := keyring.Config{
-		PassDir:                 "/primary/store",
-		PassPrefix:              "credentials",
-		PassageIdentitiesFile:   "/primary/identities",
-		LibSecretCollectionName: "primary",
+		PassDir:                   "/primary/store",
+		PassPrefix:                "credentials",
+		PassageIdentitiesFile:     "/primary/identities",
+		LibSecretCollectionName:   "primary",
+		OPVaultID:                 "primary-vault",
+		OPItemTitlePrefix:         "primary",
+		OPItemTag:                 "primary",
+		ProtonPassShareID:         "primary-share",
+		ProtonPassItemTitlePrefix: "primary",
 	}
 	overrides := keyringConfigOverrides{
-		PassPrefix:            "sessions",
-		PassageIdentitiesFile: "/session/identities",
+		PassPrefix:                "sessions",
+		PassageIdentitiesFile:     "/session/identities",
+		OPVaultID:                 "session-vault",
+		OPItemTitlePrefix:         "sessions",
+		OPItemTag:                 "sessions",
+		ProtonPassShareID:         "session-share",
+		ProtonPassItemTitlePrefix: "sessions",
 	}
 
 	sessions := overrides.apply(primary)
@@ -118,7 +149,19 @@ func TestSessionKeyringOverridesInheritPrimaryConfig(t *testing.T) {
 	if sessions.PassageIdentitiesFile != overrides.PassageIdentitiesFile {
 		t.Fatalf("PassageIdentitiesFile = %q, want override %q", sessions.PassageIdentitiesFile, overrides.PassageIdentitiesFile)
 	}
-	if primary.PassPrefix != "credentials" || primary.PassageIdentitiesFile != "/primary/identities" {
+	if sessions.OPVaultID != overrides.OPVaultID || sessions.OPItemTitlePrefix != overrides.OPItemTitlePrefix || sessions.OPItemTag != overrides.OPItemTag {
+		t.Fatal("1Password session overrides were not applied")
+	}
+	if sessions.ProtonPassShareID != overrides.ProtonPassShareID || sessions.ProtonPassItemTitlePrefix != overrides.ProtonPassItemTitlePrefix {
+		t.Fatal("Proton Pass session overrides were not applied")
+	}
+	if primary.PassPrefix != "credentials" ||
+		primary.PassageIdentitiesFile != "/primary/identities" ||
+		primary.OPVaultID != "primary-vault" ||
+		primary.OPItemTitlePrefix != "primary" ||
+		primary.OPItemTag != "primary" ||
+		primary.ProtonPassShareID != "primary-share" ||
+		primary.ProtonPassItemTitlePrefix != "primary" {
 		t.Fatal("applying session overrides modified the primary config")
 	}
 }
@@ -130,6 +173,11 @@ func TestSessionKeyringEnvironmentConfiguration(t *testing.T) {
 	t.Setenv("AWS_VAULT_SESSION_BACKEND", backend)
 	t.Setenv("AWS_VAULT_SESSION_PASS_PREFIX", "sessions")
 	t.Setenv("AWS_VAULT_SESSION_PASSAGE_IDENTITIES_FILE", "/session/identities")
+	t.Setenv("AWS_VAULT_SESSION_OP_VAULT_ID", "session-vault")
+	t.Setenv("AWS_VAULT_SESSION_OP_ITEM_TITLE_PREFIX", "sessions")
+	t.Setenv("AWS_VAULT_SESSION_OP_ITEM_TAG", "sessions")
+	t.Setenv("AWS_VAULT_SESSION_PROTON_PASS_SHARE_ID", "session-share")
+	t.Setenv("AWS_VAULT_SESSION_PROTON_PASS_ITEM_TITLE_PREFIX", "sessions")
 
 	app := kingpin.New("aws-vault", "")
 	a := ConfigureGlobals(app)
@@ -149,6 +197,15 @@ func TestSessionKeyringEnvironmentConfiguration(t *testing.T) {
 	}
 	if a.sessionKeyringOverrides.PassageIdentitiesFile != "/session/identities" {
 		t.Fatalf("session PassageIdentitiesFile = %q", a.sessionKeyringOverrides.PassageIdentitiesFile)
+	}
+	if a.sessionKeyringOverrides.OPVaultID != "session-vault" ||
+		a.sessionKeyringOverrides.OPItemTitlePrefix != "sessions" ||
+		a.sessionKeyringOverrides.OPItemTag != "sessions" {
+		t.Fatal("1Password session environment configuration was not applied")
+	}
+	if a.sessionKeyringOverrides.ProtonPassShareID != "session-share" ||
+		a.sessionKeyringOverrides.ProtonPassItemTitlePrefix != "sessions" {
+		t.Fatal("Proton Pass session environment configuration was not applied")
 	}
 }
 

--- a/cli/list.go
+++ b/cli/list.go
@@ -36,7 +36,7 @@ func ConfigureListCommand(app *kingpin.Application, a *AwsVault) {
 		BoolVar(&input.OnlyCredentials)
 
 	cmd.Action(func(c *kingpin.ParseContext) (err error) {
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -44,7 +44,7 @@ func ConfigureListCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		err = ListCommand(input, awsConfigFile, keyring, os.Stdout)
+		err = ListCommand(input, awsConfigFile, keyring, sessionKeyring, os.Stdout)
 		app.FatalIfError(err, "list")
 		return nil
 	})
@@ -94,10 +94,10 @@ func oidcLabel(sessionName, startURL string) string {
 	return fmt.Sprintf("oidc:%s", id)
 }
 
-func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyring keyring.Keyring, out io.Writer) (err error) {
+func ListCommand(input ListCommandInput, awsConfigFile *vault.ConfigFile, keyring, sessionKeyringImpl keyring.Keyring, out io.Writer) (err error) {
 	credentialKeyring := &vault.CredentialKeyring{Keyring: keyring}
 	oidcTokenKeyring := &vault.OIDCTokenKeyring{Keyring: credentialKeyring.Keyring}
-	sessionKeyring := &vault.SessionKeyring{Keyring: credentialKeyring.Keyring}
+	sessionKeyring := &vault.SessionKeyring{Keyring: sessionKeyringImpl}
 
 	credentialsNames, err := credentialKeyring.Keys()
 	if err != nil {

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -217,7 +217,7 @@ region = us-east-1
 func captureListOutput(t *testing.T, input ListCommandInput, configFile *vault.ConfigFile, kr keyring.Keyring) string {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := ListCommand(input, configFile, kr, &buf); err != nil {
+	if err := ListCommand(input, configFile, kr, kr, &buf); err != nil {
 		t.Fatalf("ListCommand error: %v", err)
 	}
 	return buf.String()

--- a/cli/login.go
+++ b/cli/login.go
@@ -77,7 +77,7 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 		input.Config.ChainedGetSessionTokenDuration = input.SessionDuration
 		input.Config.AssumeRoleDuration = input.SessionDuration
 		input.Config.GetFederationTokenDuration = input.SessionDuration
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -86,13 +86,13 @@ func ConfigureLoginCommand(app *kingpin.Application, a *AwsVault) {
 			return err
 		}
 
-		err = LoginCommand(context.Background(), input, f, keyring)
+		err = LoginCommand(context.Background(), input, f, keyring, sessionKeyring)
 		app.FatalIfError(err, "login")
 		return nil
 	})
 }
 
-func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *vault.ConfigFile, keyring keyring.Keyring) (credsProvider aws.CredentialsProvider, err error) {
+func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) (credsProvider aws.CredentialsProvider, err error) {
 	if input.ProfileName == "" {
 		// When no profile is specified, source credentials from the environment
 		configFromEnv, err := awsconfig.NewEnvConfig()
@@ -118,6 +118,7 @@ func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *v
 			ckr := &vault.CredentialKeyring{Keyring: keyring}
 			t := vault.TempCredentialsCreator{
 				Keyring:                   ckr,
+				SessionKeyring:            sessionKeyring,
 				DisableSessions:           input.NoSession,
 				DisableSessionsForProfile: config.ProfileName,
 			}
@@ -135,6 +136,7 @@ func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *v
 		ckr := &vault.CredentialKeyring{Keyring: keyring}
 		t := vault.TempCredentialsCreator{
 			Keyring:                   ckr,
+			SessionKeyring:            sessionKeyring,
 			DisableSessions:           input.NoSession,
 			DisableSessionsForProfile: config.ProfileName,
 		}
@@ -149,7 +151,7 @@ func getCredsProvider(input LoginCommandInput, config *vault.ProfileConfig, f *v
 
 // LoginCommand creates a login URL for the AWS Management Console using the method described at
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
-func LoginCommand(ctx context.Context, input LoginCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+func LoginCommand(ctx context.Context, input LoginCommandInput, f *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) error {
 	// An empty ProfileName is valid for login: getCredsProvider falls back to
 	// environment credentials or an interactive profile picker. Only guard when
 	// the user explicitly named a profile.
@@ -162,7 +164,7 @@ func LoginCommand(ctx context.Context, input LoginCommandInput, f *vault.ConfigF
 		return fmt.Errorf("Error loading config: %w", err)
 	}
 
-	credsProvider, err := getCredsProvider(input, config, f, keyring)
+	credsProvider, err := getCredsProvider(input, config, f, keyring, sessionKeyring)
 	if err != nil {
 		return err
 	}

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -41,18 +41,25 @@ func ConfigureRemoveCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		err = RemoveCommand(input, keyring)
+		sessionKeyring := keyring
+		if input.SessionsOnly {
+			sessionKeyring, err = a.SessionKeyring()
+			if err != nil {
+				return err
+			}
+		}
+		err = RemoveCommand(input, keyring, sessionKeyring)
 		app.FatalIfError(err, "remove")
 		return nil
 	})
 }
 
-func RemoveCommand(input RemoveCommandInput, keyring keyring.Keyring) error {
+func RemoveCommand(input RemoveCommandInput, keyring, sessionKeyring keyring.Keyring) error {
 	ckr := &vault.CredentialKeyring{Keyring: keyring}
 
 	// Legacy --sessions-only option for backwards compatibility, use aws-vault clear instead
 	if input.SessionsOnly {
-		sk := &vault.SessionKeyring{Keyring: ckr.Keyring}
+		sk := &vault.SessionKeyring{Keyring: sessionKeyring}
 		n, err := sk.RemoveForProfile(input.ProfileName)
 		if err != nil {
 			return err

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -40,7 +40,7 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 		if err != nil {
 			return err
 		}
-		keyring, err := a.Keyring()
+		keyring, sessionKeyring, err := a.Keyrings()
 		if err != nil {
 			return err
 		}
@@ -56,13 +56,13 @@ func ConfigureRotateCommand(app *kingpin.Application, a *AwsVault) {
 			input.ProfileName = ProfileName
 		}
 
-		err = RotateCommand(input, f, keyring)
+		err = RotateCommand(input, f, keyring, sessionKeyring)
 		app.FatalIfError(err, "rotate")
 		return nil
 	})
 }
 
-func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyring.Keyring) error {
+func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring, sessionKeyring keyring.Keyring) error {
 	if !profileResolvable(f, keyring, input.ProfileName) {
 		return fmt.Errorf("profile '%s' not found in ~/.aws/config and no stored credentials exist for it", input.ProfileName)
 	}
@@ -101,7 +101,7 @@ func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyrin
 		credsProvider = vault.NewMasterCredentialsProvider(ckr, config.ProfileName)
 	} else {
 		// Can't always disable sessions completely, might need to use session for MFA-Protected API Access
-		credsProvider, err = vault.NewTempCredentialsProvider(config, ckr, input.NoSession, true)
+		credsProvider, err = vault.NewTempCredentialsProvider(config, ckr, sessionKeyring, input.NoSession, true)
 		if err != nil {
 			return fmt.Errorf("Error getting temporary credentials: %w", err)
 		}
@@ -136,7 +136,7 @@ func RotateCommand(input RotateCommandInput, f *vault.ConfigFile, keyring keyrin
 	}
 
 	// Delete old sessions
-	sk := &vault.SessionKeyring{Keyring: ckr.Keyring}
+	sk := &vault.SessionKeyring{Keyring: sessionKeyring}
 	profileNames, err := getProfilesInChain(input.ProfileName, configLoader)
 	for _, profileName := range profileNames {
 		if n, _ := sk.RemoveForProfile(profileName); n > 0 {

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -155,14 +155,24 @@ To configure the default flag values of `aws-vault` and its subcommands:
 | Variable | Description | Flag |
 | --- | --- | --- |
 | `AWS_VAULT_BACKEND` | Secret backend to use | `--backend` |
+| `AWS_VAULT_SESSION_BACKEND` | Secret backend to use for sessions | `--session-backend` |
 | `AWS_VAULT_BIOMETRICS` | Use biometric authentication using TouchID, if supported | `--biometrics` |
 | `AWS_VAULT_KEYCHAIN_NAME` | Name of macOS keychain to use | `--keychain` |
+| `AWS_VAULT_SESSION_KEYCHAIN_NAME` | Name of macOS keychain to use for sessions | `--session-keychain` |
 | `AWS_VAULT_AUTO_LOGOUT` | Enable auto-logout when doing `login` | `--auto-logout` |
 | `AWS_VAULT_PROMPT` | Prompt driver to use | `--prompt` |
+| `AWS_VAULT_SECRET_SERVICE_COLLECTION_NAME` | Name of secret-service collection to use | `--secret-service-collection` |
+| `AWS_VAULT_SESSION_SECRET_SERVICE_COLLECTION_NAME` | Name of secret-service collection to use for sessions | `--session-secret-service-collection` |
 | `AWS_VAULT_PASS_PASSWORD_STORE_DIR` | Pass password store directory | `--pass-dir` |
+| `AWS_VAULT_SESSION_PASS_PASSWORD_STORE_DIR` | Pass password store directory to use for sessions | `--session-pass-dir` |
 | `AWS_VAULT_PASS_CMD` | Name of the pass executable | `--pass-cmd` |
+| `AWS_VAULT_SESSION_PASS_CMD` | Name of the pass executable to use for sessions | `--session-pass-cmd` |
 | `AWS_VAULT_PASS_PREFIX` | Prefix to prepend to the item path stored in pass | `--pass-prefix` |
+| `AWS_VAULT_SESSION_PASS_PREFIX` | Prefix to prepend to session item paths stored in pass | `--session-pass-prefix` |
+| `AWS_VAULT_PASSAGE_IDENTITIES_FILE` | Passage identities file | `--passage-identities-file` |
+| `AWS_VAULT_SESSION_PASSAGE_IDENTITIES_FILE` | Passage identities file to use for sessions | `--session-passage-identities-file` |
 | `AWS_VAULT_FILE_DIR` | Directory for the "file" password store | `--file-dir` |
+| `AWS_VAULT_SESSION_FILE_DIR` | Directory for the session "file" password store | `--session-file-dir` |
 | `AWS_VAULT_FILE_PASSPHRASE` | Password for the "file" password store | — |
 | `AWS_VAULT_DURATION` | Duration of the temporary or assume-role session | `--duration` |
 | `AWS_VAULT_OP_TIMEOUT` | Timeout for 1Password Service Account operations | `--op-timeout` |

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -177,14 +177,19 @@ To configure the default flag values of `aws-vault` and its subcommands:
 | `AWS_VAULT_DURATION` | Duration of the temporary or assume-role session | `--duration` |
 | `AWS_VAULT_OP_TIMEOUT` | Timeout for 1Password Service Account operations | `--op-timeout` |
 | `AWS_VAULT_OP_VAULT_ID` | UUID of the 1Password vault | `--op-vault-id` |
+| `AWS_VAULT_SESSION_OP_VAULT_ID` | UUID of the 1Password vault to use for sessions | `--session-op-vault-id` |
 | `AWS_VAULT_OP_ITEM_TITLE_PREFIX` | Prefix to prepend to 1Password item titles | `--op-item-title-prefix` |
+| `AWS_VAULT_SESSION_OP_ITEM_TITLE_PREFIX` | Prefix to prepend to 1Password session item titles | `--session-op-item-title-prefix` |
 | `AWS_VAULT_OP_ITEM_TAG` | Tag to apply to 1Password items | `--op-item-tag` |
+| `AWS_VAULT_SESSION_OP_ITEM_TAG` | Tag to apply to 1Password session items | `--session-op-item-tag` |
 | `AWS_VAULT_OP_CONNECT_HOST` | 1Password Connect server HTTP(S) URI | `--op-connect-host` |
 | `AWS_VAULT_OP_CONNECT_TOKEN` | 1Password Connect server access token | — |
 | `AWS_VAULT_OP_SERVICE_ACCOUNT_TOKEN` | 1Password service account token | — |
 | `AWS_VAULT_OP_DESKTOP_ACCOUNT_ID` | 1Password Desktop App account name or account UUID | `--op-desktop-account-id` |
 | `AWS_VAULT_PROTON_PASS_SHARE_ID` | Share ID of the Proton Pass vault to use | `--proton-pass-share-id` |
+| `AWS_VAULT_SESSION_PROTON_PASS_SHARE_ID` | Share ID of the Proton Pass vault to use for sessions | `--session-proton-pass-share-id` |
 | `AWS_VAULT_PROTON_PASS_ITEM_TITLE_PREFIX` | Prefix to prepend to Proton Pass item titles | `--proton-pass-item-title-prefix` |
+| `AWS_VAULT_SESSION_PROTON_PASS_ITEM_TITLE_PREFIX` | Prefix to prepend to Proton Pass session item titles | `--session-proton-pass-item-title-prefix` |
 | `AWS_VAULT_PROTON_PASS_API_BASE` | Proton API base URL | `--proton-pass-api-base` |
 | `AWS_VAULT_PROTON_PASS_TIMEOUT` | Timeout for Proton Pass API operations | `--proton-pass-timeout` |
 | `AWS_VAULT_PROFILE_ENV` | Set `AWS_PROFILE` instead of injecting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to allow profile-based SDK auth | `profile-env` (for `exec`) |

--- a/docs/content/docs/managing-sessions.md
+++ b/docs/content/docs/managing-sessions.md
@@ -72,6 +72,28 @@ You can also specify a profile to remove sessions for this profile only.
 aws-vault clear [profile]
 ```
 
+## Using a separate session keyring
+
+Cached sessions can use a different keyring backend or backend configuration from long-lived credentials. If no
+session setting is specified, both use the same keyring instance as before. Session settings inherit the corresponding
+primary settings unless explicitly overridden. OIDC tokens remain in the primary keyring.
+
+Environment variables keep the configuration consistent across commands. For example, Passage can use a
+passphrase-protected identity for long-lived credentials and a separate identity without a passphrase for cached
+sessions:
+
+```bash
+export AWS_VAULT_BACKEND=passage
+export AWS_VAULT_PASS_PASSWORD_STORE_DIR="$HOME/.passage/store"
+export AWS_VAULT_PASS_PREFIX=aws
+export AWS_VAULT_PASSAGE_IDENTITIES_FILE="$HOME/.passage/identities-with-passphrase"
+
+export AWS_VAULT_SESSION_PASS_PREFIX=aws-sessions
+export AWS_VAULT_SESSION_PASSAGE_IDENTITIES_FILE="$HOME/.passage/identities-without-passphrase"
+```
+
+The [configuration reference](/docs/config#environment-variables) lists the corresponding command-line options.
+
 ## Using `--no-session`
 
 AWS Vault will typically create temporary credentials using a combination of `GetSessionToken` and `AssumeRole`,

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -141,8 +141,9 @@ func NewAssumeRoleWithWebIdentityProvider(k keyring.Keyring, config *ProfileConf
 	return p, nil
 }
 
-// NewSSORoleCredentialsProvider creates a provider for SSO credentials
-func NewSSORoleCredentialsProvider(k keyring.Keyring, config *ProfileConfig, useSessionCache bool) (aws.CredentialsProvider, error) {
+// NewSSORoleCredentialsProvider creates a provider for SSO credentials using
+// separate OIDC and session keyrings.
+func NewSSORoleCredentialsProvider(oidcKeyring, sessionKeyring keyring.Keyring, config *ProfileConfig, useSessionCache bool) (aws.CredentialsProvider, error) {
 	cfg := NewAwsConfig(config.SSORegion, config.STSRegionalEndpoints, config.EndpointURL)
 
 	ssoRoleCredentialsProvider := &SSORoleCredentialsProvider{
@@ -155,14 +156,14 @@ func NewSSORoleCredentialsProvider(k keyring.Keyring, config *ProfileConfig, use
 	}
 
 	if useSessionCache {
-		ssoRoleCredentialsProvider.OIDCTokenCache = OIDCTokenKeyring{Keyring: k}
+		ssoRoleCredentialsProvider.OIDCTokenCache = OIDCTokenKeyring{Keyring: oidcKeyring}
 		return &CachedSessionProvider{
 			SessionKey: SessionMetadata{
 				Type:        "sso.GetRoleCredentials",
 				ProfileName: config.ProfileName,
 				MfaSerial:   config.SSOStartURL,
 			},
-			Keyring:         &SessionKeyring{Keyring: k},
+			Keyring:         &SessionKeyring{Keyring: sessionKeyring},
 			ExpiryWindow:    defaultExpirationWindow,
 			SessionProvider: ssoRoleCredentialsProvider,
 		}, nil
@@ -347,6 +348,8 @@ func FindMasterCredentialsNameFor(profileName string, keyring *CredentialKeyring
 
 type TempCredentialsCreator struct {
 	Keyring *CredentialKeyring
+	// SessionKeyring is the keyring used for cached sessions.
+	SessionKeyring keyring.Keyring
 	// DisableSessions will disable the use of GetSessionToken
 	DisableSessions bool
 	// DisableCache will disable the use of the session cache
@@ -421,7 +424,7 @@ func (t *TempCredentialsCreator) primeWithGetSessionToken(config *ProfileConfig,
 
 	t.chainedMfa = config.MfaSerial
 	log.Printf("profile %s: using GetSessionToken %s", config.ProfileName, mfaDetails(false, config))
-	sourcecredsProvider, err := NewSessionTokenProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
+	sourcecredsProvider, err := NewSessionTokenProvider(sourcecredsProvider, t.SessionKeyring, config, !t.DisableCache)
 	if err != nil {
 		return sourcecredsProvider, false, err
 	}
@@ -480,7 +483,7 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 		config.MfaSerial = ""
 	}
 	log.Printf("profile %s: using AssumeRole %s", config.ProfileName, mfaDetails(isMfaChained, config))
-	return NewAssumeRoleProvider(sourcecredsProvider, t.Keyring.Keyring, config, !t.DisableCache)
+	return NewAssumeRoleProvider(sourcecredsProvider, t.SessionKeyring, config, !t.DisableCache)
 }
 
 func (t *TempCredentialsCreator) GetProviderForProfile(config *ProfileConfig) (aws.CredentialsProvider, error) {
@@ -495,17 +498,17 @@ func (t *TempCredentialsCreator) GetProviderForProfile(config *ProfileConfig) (a
 
 	if config.HasSSOStartURL() {
 		log.Printf("profile %s: using SSO role credentials", config.ProfileName)
-		return NewSSORoleCredentialsProvider(t.Keyring.Keyring, config, !t.DisableCache)
+		return NewSSORoleCredentialsProvider(t.Keyring.Keyring, t.SessionKeyring, config, !t.DisableCache)
 	}
 
 	if config.HasWebIdentity() {
 		log.Printf("profile %s: using web identity", config.ProfileName)
-		return NewAssumeRoleWithWebIdentityProvider(t.Keyring.Keyring, config, !t.DisableCache)
+		return NewAssumeRoleWithWebIdentityProvider(t.SessionKeyring, config, !t.DisableCache)
 	}
 
 	if config.HasCredentialProcess() {
 		log.Printf("profile %s: using credential process", config.ProfileName)
-		return NewCredentialProcessProvider(t.Keyring.Keyring, config, !t.DisableCache)
+		return NewCredentialProcessProvider(t.SessionKeyring, config, !t.DisableCache)
 	}
 
 	return nil, fmt.Errorf("profile %s: credentials missing", config.ProfileName)
@@ -595,9 +598,11 @@ func mfaDetails(mfaChained bool, config *ProfileConfig) string {
 }
 
 // NewTempCredentialsProvider creates a credential provider for the given config
-func NewTempCredentialsProvider(config *ProfileConfig, keyring *CredentialKeyring, disableSessions bool, disableCache bool) (aws.CredentialsProvider, error) {
+// using a separate keyring for cached sessions.
+func NewTempCredentialsProvider(config *ProfileConfig, credentialsKeyring *CredentialKeyring, sessionKeyring keyring.Keyring, disableSessions bool, disableCache bool) (aws.CredentialsProvider, error) {
 	t := TempCredentialsCreator{
-		Keyring:         keyring,
+		Keyring:         credentialsKeyring,
+		SessionKeyring:  sessionKeyring,
 		DisableSessions: disableSessions,
 		DisableCache:    disableCache,
 	}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -487,6 +487,10 @@ func (t *TempCredentialsCreator) getSourceCredWithSession(config *ProfileConfig,
 }
 
 func (t *TempCredentialsCreator) GetProviderForProfile(config *ProfileConfig) (aws.CredentialsProvider, error) {
+	if t.SessionKeyring == nil {
+		t.SessionKeyring = t.Keyring.Keyring
+	}
+
 	hasStoredCredentials, err := t.Keyring.Has(config.ProfileName)
 	if err != nil {
 		return nil, err

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -61,7 +61,7 @@ web_identity_token_process = oidccli raw
 	}
 
 	ckr := newSeededKeyring(t, "")
-	p, err := vault.NewTempCredentialsProvider(config, ckr, true, true)
+	p, err := vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,6 +69,74 @@ web_identity_token_process = oidccli raw
 	_, ok := p.(*vault.AssumeRoleWithWebIdentityProvider)
 	if !ok {
 		t.Fatalf("Expected AssumeRoleWithWebIdentityProvider, got %T", p)
+	}
+}
+
+func TestTempCredentialsProviderUsesSeparateSessionKeyring(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[profile source]
+region=us-east-1
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := (&vault.ConfigLoader{File: configFile, ActiveProfile: "source"}).GetProfileConfig("source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.MfaToken = "123456"
+
+	credentials := newSeededKeyring(t, "source")
+	sessions := keyring.NewArrayKeyring(nil)
+	p, err := vault.NewTempCredentialsProvider(config, credentials, sessions, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cached, ok := p.(*vault.CachedSessionProvider)
+	if !ok {
+		t.Fatalf("expected CachedSessionProvider, got %T", p)
+	}
+	if cached.Keyring.Keyring != sessions {
+		t.Fatal("cached session provider did not use the session keyring")
+	}
+}
+
+func TestSSOProviderKeepsOIDCTokenInPrimaryKeyring(t *testing.T) {
+	primary := keyring.NewArrayKeyring(nil)
+	sessions := keyring.NewArrayKeyring(nil)
+	config := &vault.ProfileConfig{
+		ProfileName:  "sso",
+		SSOStartURL:  "https://example.awsapps.com/start",
+		SSORegion:    "us-east-1",
+		SSOAccountID: "111122223333",
+		SSORoleName:  "ReadOnly",
+	}
+
+	p, err := vault.NewSSORoleCredentialsProvider(primary, sessions, config, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cached, ok := p.(*vault.CachedSessionProvider)
+	if !ok {
+		t.Fatalf("expected CachedSessionProvider, got %T", p)
+	}
+	if cached.Keyring.Keyring != sessions {
+		t.Fatal("SSO role credentials did not use the session keyring")
+	}
+	sso, ok := cached.SessionProvider.(*vault.SSORoleCredentialsProvider)
+	if !ok {
+		t.Fatalf("expected SSORoleCredentialsProvider, got %T", cached.SessionProvider)
+	}
+	oidc, ok := sso.OIDCTokenCache.(vault.OIDCTokenKeyring)
+	if !ok {
+		t.Fatalf("expected OIDCTokenKeyring, got %T", sso.OIDCTokenCache)
+	}
+	if oidc.Keyring != primary {
+		t.Fatal("OIDC token cache did not use the primary keyring")
 	}
 }
 
@@ -97,7 +165,7 @@ role_arn=arn:aws:iam::12345678901:role/allow-view-only-access-from-other-account
 	}
 
 	ckr := newSeededKeyring(t, "")
-	p, err := vault.NewTempCredentialsProvider(config, ckr, true, true)
+	p, err := vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +213,7 @@ sso_registration_scopes=sso:account:access
 	}
 
 	ckr := newSeededKeyring(t, "")
-	p, err := vault.NewTempCredentialsProvider(config, ckr, true, true)
+	p, err := vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +251,7 @@ mfa_serial=arn:aws:iam::111111111111:mfa/user
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +296,7 @@ mfa_serial=arn:aws:iam::111111111111:mfa/user
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +342,7 @@ source_profile=source
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +398,7 @@ duration_seconds=7200
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +455,7 @@ mfa_serial=arn:aws:iam::111111111111:mfa/user
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +520,7 @@ role_arn=arn:aws:iam::111111111111:role/target
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +583,7 @@ role_arn=arn:aws:iam::111111111111:role/target
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +637,7 @@ role_arn=arn:aws:iam::111111111111:role/target
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -633,7 +701,7 @@ role_session_name=user
 
 	buf := captureLogs(t)
 
-	_, err = vault.NewTempCredentialsProvider(config, ckr, false, true)
+	_, err = vault.NewTempCredentialsProvider(config, ckr, ckr.Keyring, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #433.

## Summary

This adds optional keyring configuration for cached sessions through `--session-*` options and `AWS_VAULT_SESSION_*` environment variables.

When no session-specific setting is provided, aws-vault continues to use the same keyring instance as before. Unspecified session settings inherit the primary keyring configuration.

Long-lived credentials and SSO OIDC tokens remain in the primary keyring, while cached temporary credentials use the session keyring.

Independently of session keyring configuration, `--passage-identities-file` and `AWS_VAULT_PASSAGE_IDENTITIES_FILE` can now select the identity file used by the primary Passage backend. Passage identity selection is provided by ByteNess/keyring#109, released in keyring v1.13.0.

## Testing

- `go test ./...`
- `go vet ./...`
- Manually tested on macOS with IAM user profiles with and without MFA, and with AWS IAM Identity Center (SSO)

The separate Passage stores and identities were tested with the following setup:

```bash
mkdir -p /tmp/aws-vault/credentials
mkdir -p /tmp/aws-vault/sessions

age-keygen -o /tmp/aws-vault/key.txt
age-keygen -o /tmp/aws-vault/key2.txt

aws-vault \
  --backend=passage \
  --pass-dir=/tmp/aws-vault/credentials \
  --passage-identities-file=/tmp/aws-vault/key.txt \
  add test

aws-vault \
  --backend=passage \
  --pass-dir=/tmp/aws-vault/credentials \
  --passage-identities-file=/tmp/aws-vault/key.txt \
  --session-backend=passage \
  --session-pass-dir=/tmp/aws-vault/sessions \
  --session-passage-identities-file=/tmp/aws-vault/key2.txt \
  exec test -- env | grep AWS
```

## AI disclosure

OpenAI Codex assisted with the implementation, tests, documentation, and review. I reviewed and edited the complete diff and manually tested the behaviour described above.

### Checklist

- [x] One logical change; unrelated fixes split into separate PRs
- [x] New behaviour has tests; bug fixes include a regression test where practical
- [x] Docs and/or `README.md` updated if the change is user-visible, breaking changes are called out explicitly
- [x] No real credentials, access keys, session tokens, MFA serials, or full account IDs anywhere in the diff, tests, or description
