### PR TITLE
feat: expose AWS_ACCOUNT_ID to exec and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    AWS_CREDENTIAL_EXPIRATION=2020-04-16T11:16:27Z
    ```
 
+   When the account the credentials belong to is known from the profile config (`role_arn`, `sso_account_id` or `aws_account_id`), `AWS_ACCOUNT_ID` is exposed too.
+
 2. **Local metadata server** is started. This approach has the advantage that anything that uses Amazon's SDKs will automatically refresh credentials as needed, so session times can be as short as possible.
 
    ```shell

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -197,9 +197,15 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		return 0, fmt.Errorf("Error loading config: %w", err)
 	}
 
-	credsProvider, err := vault.NewTempCredentialsProvider(config, &vault.CredentialKeyring{Keyring: keyring}, input.NoSession, false)
+	ckr := &vault.CredentialKeyring{Keyring: keyring}
+	credsProvider, err := vault.NewTempCredentialsProvider(config, ckr, input.NoSession, false)
 	if err != nil {
 		return 0, fmt.Errorf("Error getting temporary credentials: %w", err)
+	}
+
+	accountID, err := vault.AccountIDForProfile(config, ckr)
+	if err != nil {
+		return 0, fmt.Errorf("Error determining account ID: %w", err)
 	}
 
 	subshellHelp := ""
@@ -208,7 +214,7 @@ func ExecCommand(input ExecCommandInput, f *vault.ConfigFile, keyring keyring.Ke
 		subshellHelp = fmt.Sprintf("Starting subshell %s, use `exit` to exit the subshell", input.Command)
 	}
 
-	cmdEnv := createEnv(input.ProfileName, config.Region, config.EndpointURL)
+	cmdEnv := createEnv(input.ProfileName, config.Region, config.EndpointURL, accountID)
 
 	if input.StartEc2Server {
 		if server.IsProxyRunning() {
@@ -275,7 +281,7 @@ func printToStderr(helpMsg string) {
 	fmt.Fprint(os.Stderr, helpMsg, "\n")
 }
 
-func createEnv(profileName string, region string, endpointURL string) environ {
+func createEnv(profileName string, region string, endpointURL string, accountID string) environ {
 	env := environ(os.Environ())
 	env.Unset("AWS_ACCESS_KEY_ID")
 	env.Unset("AWS_SECRET_ACCESS_KEY")
@@ -285,6 +291,9 @@ func createEnv(profileName string, region string, endpointURL string) environ {
 	env.Unset("AWS_DEFAULT_PROFILE")
 	env.Unset("AWS_PROFILE")
 	env.Unset("AWS_SDK_LOAD_CONFIG")
+	// SDKs pair AWS_ACCOUNT_ID with the static credentials in the environment, so an inherited
+	// value must not outlive the credentials it described.
+	env.Unset("AWS_ACCOUNT_ID")
 
 	env.Set("AWS_VAULT", profileName)
 
@@ -299,6 +308,11 @@ func createEnv(profileName string, region string, endpointURL string) environ {
 	if endpointURL != "" {
 		log.Printf("Setting subprocess env: AWS_ENDPOINT_URL=%s", endpointURL)
 		env.Set("AWS_ENDPOINT_URL", endpointURL)
+	}
+
+	if accountID != "" {
+		log.Printf("Setting subprocess env: AWS_ACCOUNT_ID=%s", accountID)
+		env.Set("AWS_ACCOUNT_ID", accountID)
 	}
 
 	return env

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -93,6 +93,37 @@ func TestExecCommand(t *testing.T) {
 	}
 }
 
+func TestCreateEnvAccountID(t *testing.T) {
+	t.Setenv("AWS_ACCOUNT_ID", "stale")
+
+	env := createEnv("llamas", "us-east-1", "", "123456789012")
+	if got := envValue(env, "AWS_ACCOUNT_ID"); got != "123456789012" {
+		t.Fatalf("AWS_ACCOUNT_ID = %q, want %q", got, "123456789012")
+	}
+	if got := envValue(env, "AWS_VAULT"); got != "llamas" {
+		t.Fatalf("AWS_VAULT = %q, want %q", got, "llamas")
+	}
+
+	env = createEnv("llamas", "us-east-1", "", "")
+	if _, ok := lookupEnv(env, "AWS_ACCOUNT_ID"); ok {
+		t.Fatalf("AWS_ACCOUNT_ID should be unset when the account is unknown, env: %v", env)
+	}
+}
+
+func envValue(env []string, key string) string {
+	v, _ := lookupEnv(env, key)
+	return v
+}
+
+func lookupEnv(env []string, key string) (string, bool) {
+	for _, entry := range env {
+		if strings.HasPrefix(entry, key+"=") {
+			return strings.TrimPrefix(entry, key+"="), true
+		}
+	}
+	return "", false
+}
+
 // TestExecCommandHelper is the child-process entry point. It is invoked by
 // TestExecCommand via os.Args[0] with AWS_VAULT_EXEC_TEST_HELPER=1. When that
 // variable is absent (normal test run) the function returns immediately and has

--- a/cli/export.go
+++ b/cli/export.go
@@ -119,18 +119,23 @@ func ExportCommand(input ExportCommandInput, f *vault.ConfigFile, keyring keyrin
 		return fmt.Errorf("Error getting temporary credentials: %w", err)
 	}
 
+	accountID, err := vault.AccountIDForProfile(config, ckr)
+	if err != nil {
+		return fmt.Errorf("Error determining account ID: %w", err)
+	}
+
 	if input.Format == FormatTypeExportJSON {
-		return printJSON(input, credsProvider)
+		return printJSON(input, credsProvider, accountID)
 	} else if input.Format == FormatTypeExportINI {
-		return printINI(credsProvider, input.ProfileName, config.Region)
+		return printINI(credsProvider, input.ProfileName, config.Region, accountID)
 	} else if input.Format == FormatTypeExportEnv {
-		return printEnv(input, credsProvider, config.Region, "export ")
+		return printEnv(input, credsProvider, config.Region, accountID, "export ")
 	} else {
-		return printEnv(input, credsProvider, config.Region, "")
+		return printEnv(input, credsProvider, config.Region, accountID, "")
 	}
 }
 
-func printJSON(input ExportCommandInput, credsProvider aws.CredentialsProvider) error {
+func printJSON(input ExportCommandInput, credsProvider aws.CredentialsProvider, accountID string) error {
 	// AwsCredentialHelperData is metadata for AWS CLI credential process
 	// See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
 	type AwsCredentialHelperData struct {
@@ -139,6 +144,7 @@ func printJSON(input ExportCommandInput, credsProvider aws.CredentialsProvider) 
 		SecretAccessKey string `json:"SecretAccessKey"`
 		SessionToken    string `json:"SessionToken,omitempty"`
 		Expiration      string `json:"Expiration,omitempty"`
+		AccountID       string `json:"AccountId,omitempty"`
 	}
 
 	creds, err := credsProvider.Retrieve(context.TODO())
@@ -151,6 +157,7 @@ func printJSON(input ExportCommandInput, credsProvider aws.CredentialsProvider) 
 		AccessKeyID:     creds.AccessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
+		AccountID:       accountID,
 	}
 
 	if creds.CanExpire {
@@ -176,7 +183,7 @@ func mustNewKey(s *ini.Section, name, val string) {
 	}
 }
 
-func printINI(credsProvider aws.CredentialsProvider, profilename, region string) error {
+func printINI(credsProvider aws.CredentialsProvider, profilename, region, accountID string) error {
 	creds, err := credsProvider.Retrieve(context.TODO())
 	if err != nil {
 		return fmt.Errorf("Failed to get credentials for %s: %w", profilename, err)
@@ -195,6 +202,7 @@ func printINI(credsProvider aws.CredentialsProvider, profilename, region string)
 		mustNewKey(s, "aws_credential_expiration", iso8601.Format(creds.Expires))
 	}
 	mustNewKey(s, "region", region)
+	mustNewKey(s, "aws_account_id", accountID)
 
 	_, err = f.WriteTo(os.Stdout)
 	if err != nil {
@@ -204,7 +212,7 @@ func printINI(credsProvider aws.CredentialsProvider, profilename, region string)
 	return nil
 }
 
-func printEnv(input ExportCommandInput, credsProvider aws.CredentialsProvider, region, prefix string) error {
+func printEnv(input ExportCommandInput, credsProvider aws.CredentialsProvider, region, accountID, prefix string) error {
 	creds, err := credsProvider.Retrieve(context.TODO())
 	if err != nil {
 		return fmt.Errorf("Failed to get credentials for %s: %w", input.ProfileName, err)
@@ -222,6 +230,9 @@ func printEnv(input ExportCommandInput, credsProvider aws.CredentialsProvider, r
 	if region != "" {
 		fmt.Printf("%sAWS_REGION=%s\n", prefix, region)
 		fmt.Printf("%sAWS_DEFAULT_REGION=%s\n", prefix, region)
+	}
+	if accountID != "" {
+		fmt.Printf("%sAWS_ACCOUNT_ID=%s\n", prefix, accountID)
 	}
 
 	return nil

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -35,3 +35,33 @@ func ExampleExportCommand() {
 	// aws_access_key_id=ABC
 	// aws_secret_access_key=XYZ
 }
+
+func ExampleExportCommand_accountID() {
+	f, err := os.CreateTemp("", "aws-config")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("[profile llamas]\naws_account_id=123456789012\n"); err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	os.Setenv("AWS_CONFIG_FILE", f.Name())
+	defer os.Unsetenv("AWS_CONFIG_FILE")
+
+	app := kingpin.New("aws-vault", "")
+	awsVault := ConfigureGlobals(app)
+	awsVault.keyringImpl = keyring.NewArrayKeyring([]keyring.Item{
+		{Key: "llamas", Data: []byte(`{"AccessKeyID":"ABC","SecretAccessKey":"XYZ"}`)},
+	})
+	ConfigureExportCommand(app, awsVault)
+	kingpin.MustParse(app.Parse([]string{
+		"export", "--format=env", "--no-session", "llamas",
+	}))
+
+	// Output:
+	// AWS_ACCESS_KEY_ID=ABC
+	// AWS_SECRET_ACCESS_KEY=XYZ
+	// AWS_ACCOUNT_ID=123456789012
+}

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -117,6 +117,37 @@ mfa_process=op item get my_aws_mfa --otp
 
 WARNING: Use of this option runs against security best practices. It is recommended that you use a dedicated MFA device.
 
+### `aws_account_id`
+
+`exec` and `export` expose the AWS account ID of the credentials as the `AWS_ACCOUNT_ID` environment variable (and as
+`AccountId` / `aws_account_id` in the `json` and `ini` export formats) whenever it can be determined from the profile
+config:
+
+* the account in `role_arn` when a role is assumed (including `web_identity_token_file` / `web_identity_token_process`
+  profiles),
+* `sso_account_id` for SSO profiles,
+* the account of the `source_profile` for profiles that chain without a `role_arn`.
+
+For profiles where none of the above applies, such as stored long-term credentials or `credential_process`, the account
+ID can be set explicitly with the `aws_account_id` option, which is the same option the AWS CLI uses:
+
+```ini
+[profile jonsmith]
+region=eu-west-1
+aws_account_id=123456789012
+```
+
+Unlike other settings, `aws_account_id` is not inherited from the `[default]` section, since an account ID belongs to
+one specific set of credentials. It applies to the `default` profile itself, to the profile that sets it, and to
+profiles that pull it in explicitly with `include_profile`.
+
+When the account is unknown, `exec` removes any `AWS_ACCOUNT_ID` inherited from the parent shell rather than passing
+it on. Note that AWS SDKs also read `AWS_ACCOUNT_ID` for
+[account-based endpoint routing](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html), so
+it is only ever set to the account the exposed credentials actually belong to. If your environment cannot reach
+account-specific endpoints (for example a restrictive egress allowlist), set `account_id_endpoint_mode = disabled` in
+your profile or `AWS_ACCOUNT_ID_ENDPOINT_MODE=disabled` in the environment.
+
 ## Environment variables
 
 To configure the default flag values of `aws-vault` and its subcommands:

--- a/docs/content/docs/sso.md
+++ b/docs/content/docs/sso.md
@@ -29,6 +29,9 @@ sso_account_id=123456789012
 sso_role_name=Administrator
 ```
 
+`exec` and `export` expose `sso_account_id` to the sub-process as the `AWS_ACCOUNT_ID` environment variable, so
+scripts can use the account ID without calling `aws sts get-caller-identity`.
+
 ## Assuming a role with SSO
 
 If your SSO Permission Set allows you to assume another IAM role

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -81,6 +81,9 @@ AWS Vault then exposes the temporary credentials to the sub-process in one of tw
    AWS_CREDENTIAL_EXPIRATION=2020-04-16T11:16:27Z
    ```
 
+   When the account the credentials belong to is known from the profile config (`role_arn`, `sso_account_id` or
+   `aws_account_id`), `AWS_ACCOUNT_ID` is exposed too. See [`aws_account_id`](/docs/config#aws_account_id).
+
 2. **Local metadata server** is started. This approach has the advantage that anything that uses Amazon's SDKs will
    automatically refresh credentials as needed, so session times can be as short as possible.
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -143,6 +143,7 @@ type ProfileSection struct {
 	SSORegion               string `ini:"sso_region,omitempty"`
 	SSOAccountID            string `ini:"sso_account_id,omitempty"`
 	SSORoleName             string `ini:"sso_role_name,omitempty"`
+	AccountID               string `ini:"aws_account_id,omitempty"`
 	WebIdentityTokenFile    string `ini:"web_identity_token_file,omitempty"`
 	WebIdentityTokenProcess string `ini:"web_identity_token_process,omitempty"`
 	STSRegionalEndpoints    string `ini:"sts_regional_endpoints,omitempty"`
@@ -425,6 +426,9 @@ func (cl *ConfigLoader) populateFromConfigFile(config *ProfileConfig, profileNam
 	if config.SSORoleName == "" {
 		config.SSORoleName = psection.SSORoleName
 	}
+	if config.AccountID == "" {
+		config.AccountID = psection.AccountID
+	}
 	if config.WebIdentityTokenFile == "" {
 		config.WebIdentityTokenFile = psection.WebIdentityTokenFile
 	}
@@ -462,10 +466,14 @@ func (cl *ConfigLoader) populateFromConfigFile(config *ProfileConfig, profileNam
 			return err
 		}
 	} else if profileName != defaultSectionName {
+		// aws_account_id is not inherited from [default]: an account ID is specific to one set of
+		// credentials, so a default would mislabel every profile that does not set its own.
+		accountID := config.AccountID
 		err := cl.populateFromConfigFile(config, defaultSectionName)
 		if err != nil {
 			return err
 		}
+		config.AccountID = accountID
 	}
 
 	// Ignore source_profile if it recursively refers to the profile
@@ -677,6 +685,9 @@ type ProfileConfig struct {
 
 	// SSORoleName specifies the AWS IAM Role name to target.
 	SSORoleName string
+
+	// AccountID specifies the AWS account ID of the profile's credentials (aws_account_id).
+	AccountID string
 
 	// SSOUseStdout specifies that the system browser should not be automatically opened
 	SSOUseStdout bool

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
@@ -508,6 +509,52 @@ func (t *TempCredentialsCreator) GetProviderForProfile(config *ProfileConfig) (a
 	}
 
 	return nil, fmt.Errorf("profile %s: credentials missing", config.ProfileName)
+}
+
+// AccountIDForProfile returns the AWS account ID the credentials for config will belong to, or ""
+// when it cannot be determined from configuration. It mirrors the provider selection in
+// GetProviderForProfile so the result always matches the credentials actually issued:
+//   - AssumeRole and AssumeRoleWithWebIdentity: the role_arn account
+//   - source_profile without role_arn: the source profile's account
+//   - SSO: sso_account_id
+//   - otherwise the explicit aws_account_id setting
+func AccountIDForProfile(config *ProfileConfig, keyring *CredentialKeyring) (string, error) {
+	hasStoredCredentials, err := keyring.Has(config.ProfileName)
+	if err != nil {
+		return "", err
+	}
+
+	accountID := ""
+	switch {
+	case hasStoredCredentials || config.HasSourceProfile():
+		if config.HasRole() {
+			accountID = accountIDFromARN(config.RoleARN)
+		} else if !hasStoredCredentials {
+			accountID, err = AccountIDForProfile(config.SourceProfile, keyring)
+			if err != nil {
+				return "", err
+			}
+		}
+	case config.HasSSOStartURL():
+		accountID = config.SSOAccountID
+	case config.HasWebIdentity():
+		accountID = accountIDFromARN(config.RoleARN)
+	}
+
+	if accountID == "" {
+		accountID = config.AccountID
+	}
+
+	return accountID, nil
+}
+
+// accountIDFromARN returns the account ID component of an ARN, or "" if it cannot be parsed.
+func accountIDFromARN(s string) string {
+	parsed, err := arn.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return parsed.AccountID
 }
 
 // canUseGetSessionToken determines if GetSessionToken should be used, and if not returns a reason

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -658,6 +658,99 @@ role_session_name=user
 	}
 }
 
+func TestAccountIDForProfile(t *testing.T) {
+	f := newConfigFile(t, []byte(`
+[default]
+aws_account_id=999999999999
+
+[profile sso]
+sso_start_url=https://xxxx.awsapps.com/start
+sso_region=eu-west-1
+sso_account_id=111111111111
+sso_role_name=Administrator
+
+[profile role-from-sso]
+role_arn=arn:aws:iam::222222222222:role/Other
+source_profile=sso
+
+[profile chained-no-role]
+source_profile=sso
+
+[profile stored]
+region=eu-west-1
+
+[profile stored-with-explicit-id]
+aws_account_id=333333333333
+
+[profile role-from-stored]
+role_arn=arn:aws:iam::444444444444:role/Admin
+source_profile=stored
+
+[profile webidentity]
+role_arn=arn:aws:iam::555555555555:role/Web
+web_identity_token_file=/tmp/token
+
+[profile credproc]
+credential_process=/bin/true
+aws_account_id=666666666666
+
+[profile inherits-sso-but-stored]
+include_profile=sso
+
+[profile includes-default]
+include_profile=default
+
+[profile unknown]
+region=eu-west-1
+`))
+	defer os.Remove(f)
+
+	configFile, err := vault.LoadConfig(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		profile string
+		stored  string // profile that has long-term credentials in the keyring
+		want    string
+	}{
+		{profile: "sso", want: "111111111111"},
+		{profile: "role-from-sso", want: "222222222222"},
+		{profile: "chained-no-role", want: "111111111111"},
+		{profile: "stored-with-explicit-id", stored: "stored-with-explicit-id", want: "333333333333"},
+		{profile: "role-from-stored", stored: "stored", want: "444444444444"},
+		{profile: "webidentity", want: "555555555555"},
+		{profile: "credproc", want: "666666666666"},
+		// sso_account_id inherited via include_profile must not apply to keyring credentials.
+		{profile: "inherits-sso-but-stored", stored: "inherits-sso-but-stored", want: ""},
+		// aws_account_id in [default] applies only to the default profile and explicit includes.
+		{profile: "default", stored: "default", want: "999999999999"},
+		{profile: "includes-default", stored: "includes-default", want: "999999999999"},
+		{profile: "stored", stored: "stored", want: ""},
+		{profile: "unknown", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.profile, func(t *testing.T) {
+			configLoader := &vault.ConfigLoader{File: configFile, ActiveProfile: tc.profile}
+			config, err := configLoader.GetProfileConfig(tc.profile)
+			if err != nil {
+				t.Fatalf("Should have found a profile: %v", err)
+			}
+
+			ckr := newSeededKeyring(t, tc.stored)
+			got, err := vault.AccountIDForProfile(config, ckr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("AccountIDForProfile(%s) = %q, want %q", tc.profile, got, tc.want)
+			}
+		})
+	}
+}
+
 // newSeededKeyring returns a CredentialKeyring with a single set of stub
 // credentials stored under the given profile name. Pass an empty name to get
 // an empty keyring.


### PR DESCRIPTION
Set AWS_ACCOUNT_ID in the environment created by `exec` (all modes) and in the `export` env, ini (aws_account_id) and json (AccountId) output when the account the credentials belong to can be determined from the profile config.

Because AWS SDKs also read AWS_ACCOUNT_ID for account-based endpoint routing, the value is resolved by mirroring provider selection so it only ever names the account of the credentials actually handed out:

- AssumeRole and AssumeRoleWithWebIdentity: the role_arn account
- SSO: sso_account_id
- source_profile chains without role_arn: the source profile's account
- otherwise the new aws_account_id profile setting (the AWS CLI option), e.g. for stored long-term credentials or credential_process

Any AWS_ACCOUNT_ID inherited from the parent shell is removed when the account is unknown, since SDKs would pair it with the injected credentials.

aws_account_id is deliberately not inherited from the [default] section: an account ID belongs to one specific set of credentials, so a default value would silently mislabel every profile that does not set its own. It still applies to the default profile itself and to profiles that include it explicitly via include_profile.

Closes #437

<!-- What does this PR change and why? Link any related issue - required
for anything beyond a typo, doc clarification, or obvious bug fix - and
ALWAYS required if AI was involved (see AI_POLICY.md).

Drive-by AI PRs are closed!

Before opening this PR, please make sure you've read:
  - .github/CONTRIBUTING.md
  - AI_POLICY.md  (required if you used ANY AI assistance)
  - SECURITY.md   (do NOT open a public PR/issue for vulnerabilities)
PR title must follow Conventional Commits, e.g.
  feat: add 1Password Service Accounts backend
  fix(server): handle EC2 metadata timeouts cleanly
  docs: clarify pass backend setup on Fedora

Thanks for contributing to aws-vault!
-->

### Checklist

- [x] One logical change; unrelated fixes split into separate PRs
- [x] New behaviour has tests; bug fixes include a regression test where practical
- [x] Docs and/or `README.md` updated if the change is user-visible, breaking changes are called out explicitly
- [x] No real credentials, access keys, session tokens, MFA serials, or full account IDs anywhere in the diff, tests, or description
